### PR TITLE
Fix the returned value in capy_generator for font and jpg

### DIFF
--- a/src/pdfcapi.cpp
+++ b/src/pdfcapi.cpp
@@ -185,6 +185,9 @@ CAPYPDF_PUBLIC CAPYPDF_EC capy_generator_embed_jpg(CapyPDF_Generator *g,
                                                    CapyPDF_ImageId *iid) CAPYPDF_NOEXCEPT {
     auto *gen = reinterpret_cast<PdfGen *>(g);
     auto rc = gen->embed_jpg(fname);
+    if(rc) {
+        *iid = rc.value();
+    }
     return conv_err(rc);
 }
 
@@ -193,6 +196,9 @@ CAPYPDF_PUBLIC CAPYPDF_EC capy_generator_load_font(CapyPDF_Generator *g,
                                                    CapyPDF_FontId *fid) CAPYPDF_NOEXCEPT {
     auto *gen = reinterpret_cast<PdfGen *>(g);
     auto rc = gen->load_font(fname);
+    if(rc) {
+        *fid = rc.value();
+    }
     return conv_err(rc);
 }
 


### PR DESCRIPTION
This is interesting because it at first looks like it works, but it fails when you have more than one font, since the pdf output always uses the first loaded font if none is specified.