### PR TITLE
Add image interpolation to raster image support, include python and C…

### DIFF
--- a/include/capypdf.h.in
+++ b/include/capypdf.h.in
@@ -145,6 +145,12 @@ enum CAPYPDF_Intent_Subtype {
     // CAPY_INTENT_SUBTYPE_PDFE,
 };
 
+enum CAPYPDF_Image_Interpolation {
+    CAPY_INTERPOLATION_AUTO,
+    CAPY_INTERPOLATION_PIXELATED,
+    CAPY_INTERPOLATION_SMOOTH,
+};
+
 // clang-format off
 /* Not used yet.
 enum CAPYPDF_Color_Management_Policy {
@@ -255,12 +261,14 @@ CAPYPDF_PUBLIC CAPYPDF_EC capy_generator_add_page(CapyPDF_Generator *g,
                                                   CapyPDF_DrawContext *ctx) CAPYPDF_NOEXCEPT;
 CAPYPDF_PUBLIC CAPYPDF_EC capy_generator_embed_jpg(CapyPDF_Generator *g,
                                                    const char *fname,
+                                                   enum CAPYPDF_Image_Interpolation interpolate,
                                                    CapyPDF_ImageId *iid) CAPYPDF_NOEXCEPT;
 CAPYPDF_PUBLIC CAPYPDF_EC capy_generator_load_font(CapyPDF_Generator *g,
                                                    const char *fname,
                                                    CapyPDF_FontId *fid) CAPYPDF_NOEXCEPT;
 CAPYPDF_PUBLIC CAPYPDF_EC capy_generator_load_image(CapyPDF_Generator *g,
                                                     const char *fname,
+                                                    enum CAPYPDF_Image_Interpolation interpolate,
                                                     CapyPDF_ImageId *iid) CAPYPDF_NOEXCEPT;
 CAPYPDF_PUBLIC CAPYPDF_EC capy_generator_add_graphics_state(CapyPDF_Generator *g,
                                                             const CapyPDF_GraphicsState *state,

--- a/python/capypdf.py
+++ b/python/capypdf.py
@@ -93,6 +93,11 @@ class IntentSubtype(Enum):
     PDFA = 1
     # PDFE = 2
 
+class ImageInterpolation(Enum):
+    Automatic = 0
+    Pixelated = 1
+    Smooth = 2
+
 class CapyPDFException(Exception):
     def __init__(*args, **kwargs):
         Exception.__init__(*args, **kwargs)
@@ -135,7 +140,8 @@ cfunc_types = (
 
 ('capy_generator_new', [ctypes.c_char_p, ctypes.c_void_p, ctypes.c_void_p]),
 ('capy_generator_add_page', [ctypes.c_void_p, ctypes.c_void_p]),
-('capy_generator_embed_jpg', [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p]),
+('capy_generator_embed_jpg', [ctypes.c_void_p, ctypes.c_char_p, enum_type, ctypes.c_void_p]),
+('capy_generator_load_image', [ctypes.c_void_p, ctypes.c_char_p, enum_type, ctypes.c_void_p]),
 ('capy_generator_load_icc_profile', [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p]),
 ('capy_generator_load_font', [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p]),
 ('capy_generator_write', [ctypes.c_void_p]),
@@ -588,9 +594,11 @@ class Generator:
     def add_page(self, page_ctx):
         check_error(libfile.capy_generator_add_page(self, page_ctx))
 
-    def embed_jpg(self, fname):
+    def embed_jpg(self, fname, interpolate=ImageInterpolation.Automatic):
+        if not isinstance(interpolate, ImageInterpolation):
+            raise CapyPDFException('Argument must be an image interpolation.')
         iid = ImageId()
-        check_error(libfile.capy_generator_embed_jpg(self, to_bytepath(fname), ctypes.pointer(iid)))
+        check_error(libfile.capy_generator_embed_jpg(self, to_bytepath(fname), interpolate.value, ctypes.pointer(iid)))
         return iid
 
     def load_font(self, fname):
@@ -603,9 +611,11 @@ class Generator:
         check_error(libfile.capy_generator_load_icc_profile(self, to_bytepath(fname), ctypes.pointer(iid)))
         return iid
 
-    def load_image(self, fname):
+    def load_image(self, fname, interpolate=ImageInterpolation.Automatic):
+        if not isinstance(interpolate, ImageInterpolation):
+            raise CapyPDFException('Argument must be an image interpolation.')
         iid = ImageId()
-        check_error(libfile.capy_generator_load_image(self, to_bytepath(fname), ctypes.pointer(iid)))
+        check_error(libfile.capy_generator_load_image(self, to_bytepath(fname), interpolate.value, ctypes.pointer(iid)))
         return iid
 
     def write(self):

--- a/src/pdfcapi.cpp
+++ b/src/pdfcapi.cpp
@@ -182,9 +182,10 @@ CAPYPDF_EC capy_generator_add_page(CapyPDF_Generator *g,
 
 CAPYPDF_PUBLIC CAPYPDF_EC capy_generator_embed_jpg(CapyPDF_Generator *g,
                                                    const char *fname,
+                                                   enum CAPYPDF_Image_Interpolation interpolate,
                                                    CapyPDF_ImageId *iid) CAPYPDF_NOEXCEPT {
     auto *gen = reinterpret_cast<PdfGen *>(g);
-    auto rc = gen->embed_jpg(fname);
+    auto rc = gen->embed_jpg(fname, interpolate);
     if(rc) {
         *iid = rc.value();
     }
@@ -204,9 +205,10 @@ CAPYPDF_PUBLIC CAPYPDF_EC capy_generator_load_font(CapyPDF_Generator *g,
 
 CAPYPDF_PUBLIC CAPYPDF_EC capy_generator_load_image(CapyPDF_Generator *g,
                                                     const char *fname,
+                                                    enum CAPYPDF_Image_Interpolation interpolate,
                                                     CapyPDF_ImageId *iid) CAPYPDF_NOEXCEPT {
     auto *gen = reinterpret_cast<PdfGen *>(g);
-    auto rc = gen->load_image(fname);
+    auto rc = gen->load_image(fname, interpolate);
     if(rc) {
         *iid = rc.value();
     }

--- a/src/pdfdocument.hpp
+++ b/src/pdfdocument.hpp
@@ -325,9 +325,9 @@ public:
     CapyPDF_FontId get_builtin_font_id(CapyPDF_Builtin_Fonts font);
 
     // Images
-    rvoe<CapyPDF_ImageId> load_image(const std::filesystem::path &fname);
+    rvoe<CapyPDF_ImageId> load_image(const std::filesystem::path &fname, enum CAPYPDF_Image_Interpolation interpolate);
     rvoe<CapyPDF_ImageId> load_mask_image(const std::filesystem::path &fname);
-    rvoe<CapyPDF_ImageId> embed_jpg(const std::filesystem::path &fname);
+    rvoe<CapyPDF_ImageId> embed_jpg(const std::filesystem::path &fname, enum CAPYPDF_Image_Interpolation interpolate);
 
     // Graphics states
     rvoe<CapyPDF_GraphicsStateId> add_graphics_state(const GraphicsState &state);
@@ -439,15 +439,20 @@ private:
     rvoe<CapyPDF_ImageId> add_image_object(int32_t w,
                                            int32_t h,
                                            int32_t bits_per_component,
+                                           enum CAPYPDF_Image_Interpolation interpolate,
                                            ColorspaceType colorspace,
                                            std::optional<int32_t> smask_id,
                                            bool is_mask,
                                            std::string_view uncompressed_bytes);
 
-    rvoe<CapyPDF_ImageId> process_rgb_image(const rgb_image &image);
-    rvoe<CapyPDF_ImageId> process_gray_image(const gray_image &image);
-    rvoe<CapyPDF_ImageId> process_mono_image(const mono_image &image);
-    rvoe<CapyPDF_ImageId> process_cmyk_image(const cmyk_image &image);
+    rvoe<CapyPDF_ImageId> process_rgb_image(const rgb_image &image,
+                                            enum CAPYPDF_Image_Interpolation interpolate);
+    rvoe<CapyPDF_ImageId> process_gray_image(const gray_image &image,
+                                             enum CAPYPDF_Image_Interpolation interpolate);
+    rvoe<CapyPDF_ImageId> process_mono_image(const mono_image &image,
+                                             enum CAPYPDF_Image_Interpolation interpolate);
+    rvoe<CapyPDF_ImageId> process_cmyk_image(const cmyk_image &image,
+                                             enum CAPYPDF_Image_Interpolation interpolate);
 
     int32_t create_page_group();
     void pad_subset_fonts();

--- a/src/pdfgen.hpp
+++ b/src/pdfgen.hpp
@@ -55,14 +55,16 @@ public:
 
     rvoe<NoReturnValue> write();
 
-    rvoe<CapyPDF_ImageId> load_image(const std::filesystem::path &fname) {
-        return pdoc.load_image(fname);
+    rvoe<CapyPDF_ImageId> load_image(const std::filesystem::path &fname,
+                                     enum CAPYPDF_Image_Interpolation interpolate = CAPY_INTERPOLATION_AUTO) {
+        return pdoc.load_image(fname, interpolate);
     }
     rvoe<CapyPDF_ImageId> load_mask_image(const std::filesystem::path &fname) {
         return pdoc.load_mask_image(fname);
     }
-    rvoe<CapyPDF_ImageId> embed_jpg(const std::filesystem::path &fname) {
-        return pdoc.embed_jpg(fname);
+    rvoe<CapyPDF_ImageId> embed_jpg(const std::filesystem::path &fname,
+                                    enum CAPYPDF_Image_Interpolation interpolate = CAPY_INTERPOLATION_AUTO) {
+        return pdoc.embed_jpg(fname, interpolate);
     }
     rvoe<CapyPDF_EmbeddedFileId> embed_file(const std::filesystem::path &fname) {
         return pdoc.embed_file(fname);


### PR DESCRIPTION
Example of what this looks like:  [rasters.pdf](https://github.com/jpakkane/capypdf/files/12507232/rasters.pdf)

This is a change to the API.