### PR TITLE
Improve Visual Studio builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,12 +14,12 @@ soversion = 0
 header_install_subdir = 'capypdf-@0@'.format(soversion)
 
 fmt_dep = dependency('fmt')
-png_dep = dependency('libpng')
+png_dep = dependency(['libpng', 'PNG'])
 zlib_dep = dependency('zlib')
 lcms_dep = dependency('lcms2')
-jpeg_dep = dependency('libjpeg')
-freetype_dep = dependency('freetype2')
-tiff_dep = dependency('libtiff-4')
+jpeg_dep = dependency(['libjpeg', 'JPEG'])
+freetype_dep = dependency(['freetype2', 'FreeType'])
+tiff_dep = dependency(['libtiff-4', 'TIFF'])
 gtk_dep = dependency('gtk4', required: false)
 
 pubinc = include_directories('include')

--- a/python/capypdf.py
+++ b/python/capypdf.py
@@ -901,7 +901,7 @@ class Type3Shading:
         self._as_parameter_ = t3s
 
     def __del__(self):
-        check_error(libfile.capy_type3_shading_destroy_shading_destroy(self))
+        check_error(libfile.capy_type3_shading_destroy(self))
 
 
 class Type4Shading:

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,27 @@
 a4deps = [fmt_dep, png_dep, jpeg_dep, lcms_dep, tiff_dep, zlib_dep, freetype_dep]
 
+# check whether building against LCMS requires -DCMS_DLL
+a4_extra_cxxargs = []
+if host_machine.system() == 'windows'
+  lcms_test = '''
+#include <lcms2.h>
+
+int main (int argc, char *argv[])
+{
+  cmsGetEncodedCMMversion ();
+  return 0;
+}
+'''
+  cc = meson.get_compiler('c')
+  if not cc.links(
+    lcms_test,
+    dependencies: [lcms_dep],
+	name: 'LCMS can link without -DCMS_DLL',
+  )
+    a4_extra_cxxargs += '-DCMS_DLL'
+  endif
+endif
+
 capypdf_lib = shared_library('capypdf',
   'pdfcommon.cpp',
   'pdfgen.cpp',
@@ -14,7 +36,7 @@ capypdf_lib = shared_library('capypdf',
   'errorhandling.cpp',
   include_directories: [pubinc],
   #link_args: ['-static-libstdc++'],
-  cpp_args: ['-DBUILDING_CAPYPDF'],
+  cpp_args: ['-DBUILDING_CAPYPDF'] + a4_extra_cxxargs,
   dependencies: a4deps,
   gnu_symbol_visibility: 'inlineshidden',
   version: version,

--- a/src/meson.build
+++ b/src/meson.build
@@ -97,7 +97,8 @@ executable('loremipsum', 'loremipsum.cpp',
   dependencies: [capypdf_internal_dep]
 )
 
-if gtk_dep.found()
+# pdfviewer code needs to be ported to Windows (no mmap)
+if gtk_dep.found() and host_machine.system() != 'windows'
   executable('pdfviewer',
     'pdfviewer.cpp',
     'pdfparser.cpp',


### PR DESCRIPTION
Hi,

This attempts to improve the build experience on Visual Studio by:

*  Using also CMake dependency names, if applicable, for dependencies where pkg-config files are not supplied (or are broken out-of-the-box) by the dependencies' Visual Studio build systems.
*  Disable `pdfviewer` on Windows for now, since the code there need to be ported to Windows, even if one has gtk-4.x installed.
*  Fix 32-bit builds linking to shared LCMS2 builds on Windows (`CMS_DLL` needs to be defined in this case)
*  Fix up paths in the Python tests for the fonts, and GhostScript, where GhostScript is likely installed via an installer, not in `/usr`; so we also try to find the names of the GhostScript executable that is provided by the 32-bit and 64-bit Windows installers, and use the ICC profiles that are installed with the installer.
*  Fix up a wrong function name call in `capypdf.py`.

With blessings, thank you!