### PR TITLE
Refactor transparency group usage.

### DIFF
--- a/include/capypdf.h.in
+++ b/include/capypdf.h.in
@@ -438,6 +438,8 @@ CAPYPDF_PUBLIC CapyPDF_EC capy_page_properties_set_pagebox(CapyPDF_PagePropertie
                                                            double y1,
                                                            double x2,
                                                            double y2) CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_page_properties_set_transparency_group_properties(
+    CapyPDF_PageProperties *pageprop, CapyPDF_TransparencyGroupProperties *trprop) CAPYPDF_NOEXCEPT;
 
 // Generator
 
@@ -453,7 +455,6 @@ CAPYPDF_PUBLIC CapyPDF_EC capy_generator_add_form_xobject(CapyPDF_Generator *gen
 CAPYPDF_PUBLIC CapyPDF_EC
 capy_generator_add_transparency_group(CapyPDF_Generator *gen,
                                       CapyPDF_DrawContext *ctx,
-                                      const CapyPDF_TransparencyGroupProperties *opt,
                                       CapyPDF_TransparencyGroupId *out_ptr) CAPYPDF_NOEXCEPT;
 CAPYPDF_PUBLIC CapyPDF_EC capy_generator_add_color_pattern(
     CapyPDF_Generator *g, CapyPDF_DrawContext *ctx, CapyPDF_PatternId *out_ptr) CAPYPDF_NOEXCEPT;
@@ -672,6 +673,8 @@ CAPYPDF_PUBLIC CapyPDF_EC capy_dc_set_custom_page_properties(
     CapyPDF_DrawContext *ctx, const CapyPDF_PageProperties *custom_properties);
 CAPYPDF_PUBLIC CapyPDF_EC capy_dc_annotate(CapyPDF_DrawContext *ctx,
                                            CapyPDF_AnnotationId aid) CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_dc_set_transparency_group_properties(
+    CapyPDF_DrawContext *ctx, CapyPDF_TransparencyGroupProperties *trprop) CAPYPDF_NOEXCEPT;
 
 CAPYPDF_PUBLIC CapyPDF_EC capy_dc_destroy(CapyPDF_DrawContext *) CAPYPDF_NOEXCEPT;
 
@@ -822,7 +825,7 @@ CAPYPDF_PUBLIC CapyPDF_EC capy_transparency_group_properties_set_I(
 CAPYPDF_PUBLIC CapyPDF_EC capy_transparency_group_properties_set_K(
     CapyPDF_TransparencyGroupProperties *props, int32_t K) CAPYPDF_NOEXCEPT;
 CAPYPDF_PUBLIC CapyPDF_EC capy_transparency_group_properties_destroy(
-    CapyPDF_TransparencyGroupProperties *opt) CAPYPDF_NOEXCEPT;
+    CapyPDF_TransparencyGroupProperties *props) CAPYPDF_NOEXCEPT;
 
 // Raster images
 CAPYPDF_PUBLIC CapyPDF_EC capy_raster_image_builder_new(CapyPDF_RasterImageBuilder **out_ptr)

--- a/include/capypdf.hpp
+++ b/include/capypdf.hpp
@@ -77,6 +77,23 @@ public:
 };
 static_assert(sizeof(DocumentMetadata) == sizeof(void *));
 
+class TransparencyGroupProperties : public CapyC<CapyPDF_TransparencyGroupProperties> {
+public:
+    TransparencyGroupProperties() {
+        CapyPDF_TransparencyGroupProperties *tge;
+        CAPY_CPP_CHECK(capy_transparency_group_properties_new(&tge));
+        _d.reset(tge);
+    }
+
+    void set_CS(CapyPDF_DeviceColorspace cs) {
+        CAPY_CPP_CHECK(capy_transparency_group_properties_set_CS(*this, cs));
+    }
+
+    void set_I(bool I) { CAPY_CPP_CHECK(capy_transparency_group_properties_set_I(*this, I)); }
+
+    void set_K(bool K) { CAPY_CPP_CHECK(capy_transparency_group_properties_set_K(*this, K)); }
+};
+
 class PageProperties : public CapyC<CapyPDF_PageProperties> {
 public:
     PageProperties() {
@@ -87,6 +104,10 @@ public:
 
     void set_pagebox(CapyPDF_Page_Box boxtype, double x1, double y1, double x2, double y2) {
         CAPY_CPP_CHECK(capy_page_properties_set_pagebox(*this, boxtype, x1, y1, x2, y2));
+    }
+
+    void set_transparency_group_properties(TransparencyGroupProperties &trprop) {
+        CAPY_CPP_CHECK(capy_page_properties_set_transparency_group_properties(*this, trprop));
     }
 };
 
@@ -201,6 +222,10 @@ public:
         CAPY_CPP_CHECK(capy_dc_set_custom_page_properties(*this, props));
     }
 
+    void set_transparency_group_properties(TransparencyGroupProperties &trprop) {
+        CAPY_CPP_CHECK(capy_dc_set_transparency_group_properties(*this, trprop));
+    }
+
 private:
     explicit DrawContext(CapyPDF_DrawContext *dc) { _d.reset(dc); }
 };
@@ -221,23 +246,6 @@ public:
         CAPY_CPP_CHECK(capy_raster_image_builder_new(&rib));
         _d.reset(rib);
     }
-};
-
-class TransparencyGroupProperties : public CapyC<CapyPDF_TransparencyGroupProperties> {
-public:
-    TransparencyGroupProperties() {
-        CapyPDF_TransparencyGroupProperties *tge;
-        CAPY_CPP_CHECK(capy_transparency_group_properties_new(&tge));
-        _d.reset(tge);
-    }
-
-    void set_CS(CapyPDF_DeviceColorspace cs) {
-        CAPY_CPP_CHECK(capy_transparency_group_properties_set_CS(*this, cs));
-    }
-
-    void set_I(bool I) { CAPY_CPP_CHECK(capy_transparency_group_properties_set_I(*this, I)); }
-
-    void set_K(bool K) { CAPY_CPP_CHECK(capy_transparency_group_properties_set_K(*this, K)); }
 };
 
 class Generator : public CapyC<CapyPDF_Generator> {
@@ -280,10 +288,9 @@ public:
         return gsid;
     }
 
-    CapyPDF_TransparencyGroupId add_transparency_group(DrawContext &dc,
-                                                       TransparencyGroupProperties &opt) {
+    CapyPDF_TransparencyGroupId add_transparency_group(DrawContext &dct) {
         CapyPDF_TransparencyGroupId tgid;
-        CAPY_CPP_CHECK(capy_generator_add_transparency_group(*this, dc, opt, &tgid));
+        CAPY_CPP_CHECK(capy_generator_add_transparency_group(*this, dct, &tgid));
         return tgid;
     }
 

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -114,6 +114,15 @@ CAPYPDF_PUBLIC CapyPDF_EC capy_page_properties_set_pagebox(CapyPDF_PagePropertie
     RETNOERR;
 }
 
+CAPYPDF_PUBLIC CapyPDF_EC capy_page_properties_set_transparency_group_properties(
+    CapyPDF_PageProperties *pageprop,
+    CapyPDF_TransparencyGroupProperties *trprop) CAPYPDF_NOEXCEPT {
+    auto *page = reinterpret_cast<PageProperties *>(pageprop);
+    auto *tr = reinterpret_cast<TransparencyGroupProperties *>(trprop);
+    page->transparency_props = *tr;
+    RETNOERR;
+}
+
 CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_device_profile(CapyPDF_DocumentMetadata *opt,
                                                          CapyPDF_DeviceColorspace cs,
                                                          const char *profile_path)
@@ -213,13 +222,11 @@ CAPYPDF_PUBLIC CapyPDF_EC capy_generator_add_form_xobject(CapyPDF_Generator *gen
 CAPYPDF_PUBLIC CapyPDF_EC
 capy_generator_add_transparency_group(CapyPDF_Generator *gen,
                                       CapyPDF_DrawContext *ctx,
-                                      const CapyPDF_TransparencyGroupProperties *opt,
                                       CapyPDF_TransparencyGroupId *out_ptr) CAPYPDF_NOEXCEPT {
     auto *g = reinterpret_cast<PdfGen *>(gen);
     auto *dc = reinterpret_cast<PdfDrawContext *>(ctx);
-    auto *ex = reinterpret_cast<TransparencyGroupProperties const *>(opt);
 
-    auto rc = g->add_transparency_group(*dc, ex);
+    auto rc = g->add_transparency_group(*dc);
     if(rc) {
         *out_ptr = rc.value();
     }
@@ -885,6 +892,13 @@ CAPYPDF_PUBLIC CapyPDF_EC capy_dc_annotate(CapyPDF_DrawContext *ctx,
     return conv_err(dc->annotate(aid));
 }
 
+CAPYPDF_PUBLIC CapyPDF_EC capy_dc_set_transparency_group_properties(
+    CapyPDF_DrawContext *ctx, CapyPDF_TransparencyGroupProperties *trprop) CAPYPDF_NOEXCEPT {
+    auto *dc = reinterpret_cast<PdfDrawContext *>(ctx);
+    auto *tr = reinterpret_cast<TransparencyGroupProperties *>(trprop);
+    return conv_err(dc->set_transparency_properties(*tr));
+}
+
 CAPYPDF_PUBLIC CapyPDF_EC
 capy_dc_add_simple_navigation(CapyPDF_DrawContext *ctx,
                               const CapyPDF_OptionalContentGroupId *ocgarray,
@@ -1354,8 +1368,8 @@ CAPYPDF_PUBLIC CapyPDF_EC capy_transparency_group_properties_set_K(
 }
 
 CAPYPDF_PUBLIC CapyPDF_EC capy_transparency_group_properties_destroy(
-    CapyPDF_TransparencyGroupProperties *ex) CAPYPDF_NOEXCEPT {
-    delete reinterpret_cast<TransparencyGroupProperties *>(ex);
+    CapyPDF_TransparencyGroupProperties *props) CAPYPDF_NOEXCEPT {
+    delete reinterpret_cast<TransparencyGroupProperties *>(props);
     RETNOERR;
 }
 

--- a/src/document.hpp
+++ b/src/document.hpp
@@ -70,6 +70,8 @@ struct PageProperties {
 
     std::optional<double> user_unit;
 
+    std::optional<TransparencyGroupProperties> transparency_props;
+
     PageProperties merge_with(const PageProperties &o) const {
         PageProperties result = *this;
         if(o.mediabox) {
@@ -90,6 +92,10 @@ struct PageProperties {
 
         if(o.user_unit) {
             result.user_unit = o.user_unit;
+        }
+
+        if(o.transparency_props) {
+            result.transparency_props = o.transparency_props;
         }
 
         return result;
@@ -385,7 +391,7 @@ public:
     // Annotations.
     rvoe<CapyPDF_AnnotationId> create_annotation(const Annotation &a);
 
-    // Structure items
+    // Structure itemsconst std::array<const char *, 3> colorspace_names
     rvoe<CapyPDF_StructureItemId> add_structure_item(const CapyPDF_StructureType stype,
                                                      std::optional<CapyPDF_StructureItemId> parent,
                                                      std::optional<StructItemExtraData> extra);
@@ -397,8 +403,7 @@ public:
     rvoe<CapyPDF_OptionalContentGroupId> add_optional_content_group(const OptionalContentGroup &g);
 
     // Transparency groups
-    rvoe<CapyPDF_TransparencyGroupId> add_transparency_group(PdfDrawContext &ctx,
-                                                             const TransparencyGroupProperties *ex);
+    rvoe<CapyPDF_TransparencyGroupId> add_transparency_group(PdfDrawContext &ctx);
 
     std::optional<double>
     glyph_advance(CapyPDF_FontId fid, double pointsize, uint32_t codepoint) const;
@@ -444,7 +449,6 @@ private:
                                            CapyPDF_Compression compression);
 
     rvoe<NoReturnValue> generate_info_object();
-    int32_t create_page_group();
     void pad_subset_fonts();
     void pad_subset_until_space(std::vector<TTGlyphs> &subset_glyphs);
 
@@ -492,7 +496,6 @@ private:
     std::optional<int32_t> structure_root_object;
     std::optional<int32_t> structure_parent_tree_object;
     int32_t pages_object;
-    int32_t page_group_object;
     bool write_attempted = false;
 };
 

--- a/src/drawcontext.hpp
+++ b/src/drawcontext.hpp
@@ -76,7 +76,7 @@ public:
                    CapyPDF_Draw_Context_Type dtype,
                    const PdfRectangle &area);
     ~PdfDrawContext();
-    DCSerialization serialize(const TransparencyGroupProperties *trinfo = nullptr);
+    DCSerialization serialize();
 
     PdfDrawContext() = delete;
     PdfDrawContext(const PdfDrawContext &) = delete;
@@ -241,6 +241,8 @@ public:
     const PageProperties &get_custom_props() const { return custom_props; }
 
     rvoe<NoReturnValue> set_custom_page_properties(const PageProperties &new_props);
+
+    rvoe<NoReturnValue> set_transparency_properties(const TransparencyGroupProperties &props);
 
 private:
     rvoe<NoReturnValue> serialize_charsequence(const TextEvents &charseq,

--- a/src/errorhandling.cpp
+++ b/src/errorhandling.cpp
@@ -74,6 +74,7 @@ const std::array<const char *, (std::size_t)ErrorCode::NumErrors> error_texts{
 "Image is not in format required by output settings.",
 "Page reference points to a non-existing page.",
 "Title is empty.",
+"Transparency properties can only be set on pages and transparency groups.",
 };
 
 // clang-format on

--- a/src/errorhandling.hpp
+++ b/src/errorhandling.hpp
@@ -72,6 +72,7 @@ enum class ErrorCode : int32_t {
     ImageFormatNotPermitted,
     InvalidPageNumber,
     EmptyTitle,
+    WrongDCForTransp,
     // When you add an error code here, also add the string representation in the .cpp file.
     NumErrors,
 };

--- a/src/formtest.cpp
+++ b/src/formtest.cpp
@@ -132,10 +132,7 @@ int draw_group_doc() {
         groupctx->cmd_RG(0.1, 0.9, 0.2);
         groupctx->cmd_re(0, 0, 100, 100);
         groupctx->cmd_b();
-        TransparencyGroupProperties ex;
-        //        ex.I = false;
-        //        ex.K = true;
-        tgid = gen.add_transparency_group(*groupctx, &ex).value();
+        tgid = gen.add_transparency_group(*groupctx).value();
     }
     {
         auto ctxguard = gen.guarded_page_context();
@@ -201,7 +198,8 @@ int draw_transp_doc() {
                 TransparencyGroupProperties ex;
                 ex.I = false;
                 ex.K = true;
-                auto tgid = gen.add_transparency_group(*groupctx, &ex).value();
+                groupctx->set_transparency_properties(ex);
+                auto tgid = gen.add_transparency_group(*groupctx).value();
                 auto rc = ctx.push_gstate();
                 draw_gradient(ctx, shadeid, 80, 20);
                 ctx.cmd_Do(tgid);
@@ -213,7 +211,8 @@ int draw_transp_doc() {
                 TransparencyGroupProperties ex;
                 ex.I = true;
                 ex.K = true;
-                auto tgid = gen.add_transparency_group(*groupctx, &ex).value();
+                groupctx->set_transparency_properties(ex);
+                auto tgid = gen.add_transparency_group(*groupctx).value();
                 auto rc = ctx.push_gstate();
                 draw_gradient(ctx, shadeid, 80, 110);
                 ctx.cmd_Do(tgid);
@@ -225,7 +224,8 @@ int draw_transp_doc() {
                 TransparencyGroupProperties ex;
                 ex.I = false;
                 ex.K = false;
-                auto tgid = gen.add_transparency_group(*groupctx, &ex).value();
+                groupctx->set_transparency_properties(ex);
+                auto tgid = gen.add_transparency_group(*groupctx).value();
                 auto rc = ctx.push_gstate();
                 draw_gradient(ctx, shadeid, 180, 20);
                 ctx.cmd_Do(tgid);
@@ -237,7 +237,8 @@ int draw_transp_doc() {
                 TransparencyGroupProperties ex;
                 ex.I = true;
                 ex.K = false;
-                auto tgid = gen.add_transparency_group(*groupctx, &ex).value();
+                groupctx->set_transparency_properties(ex);
+                auto tgid = gen.add_transparency_group(*groupctx).value();
                 auto rc = ctx.push_gstate();
                 draw_gradient(ctx, shadeid, 180, 110);
                 ctx.cmd_Do(tgid);

--- a/src/generator.hpp
+++ b/src/generator.hpp
@@ -126,9 +126,8 @@ public:
     rvoe<PageId> add_page(PdfDrawContext &ctx);
     rvoe<CapyPDF_FormXObjectId> add_form_xobject(PdfDrawContext &ctx);
     rvoe<CapyPDF_PatternId> add_pattern(PdfDrawContext &cp);
-    rvoe<CapyPDF_TransparencyGroupId>
-    add_transparency_group(PdfDrawContext &ctx, const TransparencyGroupProperties *ex) {
-        return pdoc.add_transparency_group(ctx, ex);
+    rvoe<CapyPDF_TransparencyGroupId> add_transparency_group(PdfDrawContext &ctx) {
+        return pdoc.add_transparency_group(ctx);
     }
 
     rvoe<CapyPDF_OutlineId> add_outline(const Outline &o) { return pdoc.add_outline(o); }

--- a/src/pdfcommon.cpp
+++ b/src/pdfcommon.cpp
@@ -84,6 +84,21 @@ const std::array<const char *, (int)CAPY_STRUCTURE_TYPE_NUM_ITEMS> structure_typ
     // clang-format on
 };
 
+void TransparencyGroupProperties::serialize(std::back_insert_iterator<std::string> &app,
+                                            const char *indent) const {
+    std::format_to(app, "<<\n{}  /Type /Group\n{}  /S /Transparency\n", indent, indent);
+    if(CS) {
+        std::format_to(app, "{}  /CS {}\n", indent, colorspace_names.at((int)CS.value()));
+    }
+    if(I) {
+        std::format_to(app, "{}  /I {}\n", indent, I.value() ? "true" : "false");
+    }
+    if(K) {
+        std::format_to(app, "{}  /K {}\n", indent, K.value() ? "true" : "false");
+    }
+    std::format_to(app, "{}>>\n", indent);
+}
+
 rvoe<asciistring> asciistring::from_cstr(const char *cstr) {
     if(!is_ascii(cstr)) {
         RETERR(NotASCII);

--- a/src/pdfcommon.hpp
+++ b/src/pdfcommon.hpp
@@ -55,6 +55,8 @@ DEF_BASIC_OPERATORS(CapyPDF_TransparencyGroupId);
 namespace capypdf::internal {
 
 extern const std::array<const char *, (int)CAPY_STRUCTURE_TYPE_NUM_ITEMS> structure_type_names;
+extern const std::array<const char *, 3> colorspace_names;
+extern const std::array<const char *, 4> rendering_intent_names;
 
 // Does not check if the given buffer is valid UTF-8.
 // If it is not, UB ensues.
@@ -425,8 +427,6 @@ struct FontSubset {
     bool operator!=(const FontSubset &other) const { return !(*this == other); }
 };
 
-extern const std::array<const char *, 4> rendering_intent_names;
-
 struct Transition {
     std::optional<CapyPDF_Transition_Type> type;
     std::optional<double> duration;
@@ -449,6 +449,8 @@ struct TransparencyGroupProperties {
     std::optional<CapyPDF_DeviceColorspace> CS;
     std::optional<bool> I;
     std::optional<bool> K;
+
+    void serialize(std::back_insert_iterator<std::string> &app, const char *indent) const;
 };
 
 struct SubPageNavigation {

--- a/src/pdfwriter.cpp
+++ b/src/pdfwriter.cpp
@@ -496,12 +496,17 @@ rvoe<NoReturnValue> PdfWriter::write_delayed_page(const DelayedPage &dp) {
                    R"(<<
   /Type /Page
   /Parent {} 0 R
-  /Group {} 0 R
   /LastModified {}
 )",
                    doc.pages_object,
-                   doc.page_group_object,
                    current_date_string());
+    if(dp.custom_props.transparency_props) {
+        buf += "  /Group ";
+        dp.custom_props.transparency_props->serialize(buf_append, "  ");
+    } else if(doc.opts.default_page_properties.transparency_props) {
+        buf += "  /Group ";
+        doc.opts.default_page_properties.transparency_props->serialize(buf_append, "  ");
+    }
     PageProperties current_props = doc.opts.default_page_properties.merge_with(dp.custom_props);
     write_rectangle(buf_append, "MediaBox", *current_props.mediabox);
 

--- a/test/capypdftests.py
+++ b/test/capypdftests.py
@@ -1204,13 +1204,15 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_transparency_groups', 200, 200)
     def test_transparency_groups(self, ofilename, w, h):
-        prop = capypdf.PageProperties()
-        prop.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        page_props = capypdf.PageProperties()
+        tr_props = capypdf.TransparencyGroupProperties()
+        tr_props.set_CS(capypdf.DeviceColorspace.RGB)
+        page_props.set_transparency_group_properties(tr_props)
+        page_props.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
         opt = capypdf.DocumentMetadata()
-        opt.set_default_page_properties(prop)
+        opt.set_default_page_properties(page_props)
 
         with capypdf.Generator(ofilename, opt) as gen:
-
             # Test transparency painting within transparency group
             gstate = capypdf.GraphicsState()
             gstate.set_CA(0.5)
@@ -1224,7 +1226,7 @@ class TestPDFCreation(unittest.TestCase):
 
             with gen.page_draw_context() as page:
                 ctx = capypdf.TransparencyGroupDrawContext(gen, -100, -100, 100, 100)
-                tr_params = capypdf.TransparencyGroupParameters()
+                ctx.set_transparency_group_properties(tr_props)
 
                 # Transformation tests to locality of the transparency group's drawing context
                 ctx.cmd_cm(1, 0, 0, 1, -100, -100)
@@ -1234,7 +1236,7 @@ class TestPDFCreation(unittest.TestCase):
                 ctx.cmd_RG(1, 0, 0)
                 ctx.cmd_re(15, 15, 175, 175)
                 ctx.cmd_b() # paint both
-                tid = gen.add_transparency_group(ctx, tr_params)
+                tid = gen.add_transparency_group(ctx)
                 del ctx
 
                 page.cmd_cm(1, 0, 0, 1, 100, 100)


### PR DESCRIPTION
Now you can set the transparency explicitly:

- The default value for pages can be set in page default values
- For pages it can be overridden either with custom page props or with the explicit method
- For transparency groups it can be set with the explicit method

If unspecified, no transparency group info is written in the file.

The C++ header does not have all of the methods yet.

Ping @doctormo, with this you should be able to set I and K properly.