### PR TITLE
Add transparency group constructor and fix page limitor

### DIFF
--- a/include/capypdf.hpp
+++ b/include/capypdf.hpp
@@ -272,6 +272,13 @@ public:
         return DrawContext(dc);
     }
 
+    DrawContext
+    new_transparency_group_context(double left, double bottom, double right, double top) {
+        CapyPDF_DrawContext *dc;
+        CAPY_CPP_CHECK(capy_transparency_group_new(*this, left, bottom, right, top, &dc));
+        return DrawContext(dc);
+    }
+
     void add_page(DrawContext &dc){CAPY_CPP_CHECK(capy_generator_add_page(*this, dc))}
 
     CapyPDF_FontId load_font(const char *fname) {

--- a/src/drawcontext.cpp
+++ b/src/drawcontext.cpp
@@ -329,9 +329,6 @@ PdfDrawContext::cmd_d(double *dash_array, size_t dash_array_length, double phase
 }
 
 rvoe<NoReturnValue> PdfDrawContext::cmd_Do(CapyPDF_FormXObjectId fxoid) {
-    if(context_type != CAPY_DC_PAGE) {
-        RETERR(InvalidDrawContextType);
-    }
     CHECK_INDEXNESS(fxoid.id, doc->form_xobjects);
     std::format_to(cmd_appender, "{}/FXO{} Do\n", ind, doc->form_xobjects[fxoid.id].xobj_num);
     used_form_xobjects.insert(doc->form_xobjects[fxoid.id].xobj_num);
@@ -339,9 +336,6 @@ rvoe<NoReturnValue> PdfDrawContext::cmd_Do(CapyPDF_FormXObjectId fxoid) {
 }
 
 rvoe<NoReturnValue> PdfDrawContext::cmd_Do(CapyPDF_TransparencyGroupId trid) {
-    if(context_type != CAPY_DC_PAGE) {
-        RETERR(InvalidDrawContextType);
-    }
     CHECK_INDEXNESS(trid.id, doc->transparency_groups);
     std::format_to(cmd_appender, "{}/TG{} Do\n", ind, doc->transparency_groups[trid.id]);
     used_trgroups.insert(trid);


### PR DESCRIPTION
The PDF specification doesn't limit xform objects to just the page context.

TransparencyGroups (and all other xforms) can be rendered into other xforms.