### PR TITLE
Move the object creation to the last step in shading serialization

### DIFF
--- a/src/document.hpp
+++ b/src/document.hpp
@@ -381,10 +381,11 @@ public:
     rvoe<CapyPDF_FunctionId> add_function(PdfFunction f);
 
     // Shading
-    rvoe<int32_t> serialize_shading(const ShadingType2 &shade);
-    rvoe<int32_t> serialize_shading(const ShadingType3 &shade);
-    rvoe<int32_t> serialize_shading(const ShadingType4 &shade);
-    rvoe<int32_t> serialize_shading(const ShadingType6 &shade);
+    rvoe<FullPDFObject> serialize_shading(const PdfShading &shade);
+    rvoe<FullPDFObject> serialize_shading(const ShadingType2 &shade);
+    rvoe<FullPDFObject> serialize_shading(const ShadingType3 &shade);
+    rvoe<FullPDFObject> serialize_shading(const ShadingType4 &shade);
+    rvoe<FullPDFObject> serialize_shading(const ShadingType6 &shade);
     rvoe<CapyPDF_ShadingId> add_shading(PdfShading sh);
 
     // Patterns


### PR DESCRIPTION
This will allow the pattern serializer to construct Type 2 patterns using the same code to serialize the sh gradients.