### PR TITLE
Adds shading patterns and tiling patterns to the cpp API

### DIFF
--- a/include/capypdf.h.in
+++ b/include/capypdf.h.in
@@ -904,6 +904,9 @@ CAPYPDF_PUBLIC CapyPDF_EC capy_shading_destroy(CapyPDF_Shading *shade) CAPYPDF_N
 CAPYPDF_PUBLIC CapyPDF_EC capy_shading_set_extend(CapyPDF_Shading *shade,
                                                   int32_t starting,
                                                   int32_t ending) CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_shading_set_domain(CapyPDF_Shading *shade,
+                                                  double starting,
+                                                  double ending) CAPYPDF_NOEXCEPT;
 
 CAPYPDF_PUBLIC CapyPDF_EC capy_type3_shading_new(CapyPDF_DeviceColorspace cs,
                                                  double *coords,

--- a/python/capypdf.py
+++ b/python/capypdf.py
@@ -476,6 +476,8 @@ cfunc_types = (
 ('capy_type2_shading_new', [enum_type,
                             ctypes.c_double, ctypes.c_double, ctypes.c_double, ctypes.c_double,
                             FunctionId, ctypes.c_void_p]),
+('capy_shading_set_extend', [ctypes.c_void_p, ctypes.c_int32, ctypes.c_int32]),
+('capy_shading_set_domain', [ctypes.c_void_p, ctypes.c_double, ctypes.c_double]),
 ('capy_shading_destroy', [ctypes.c_void_p]),
 
 
@@ -1527,6 +1529,9 @@ class Type2Shading:
         e2 = 1 if ending else 0
         check_error(libfile.capy_shading_set_extend(self, e1, e2))
 
+    def set_domain(self, starting, ending):
+        check_error(libfile.capy_shading_set_domain(self, starting, ending))
+
     def __del__(self):
         check_error(libfile.capy_shading_destroy(self))
 
@@ -1543,6 +1548,9 @@ class Type3Shading:
         e1 = 1 if starting else 0
         e2 = 1 if ending else 0
         check_error(libfile.capy_shading_set_extend(self, e1, e2))
+
+    def set_domain(self, starting, ending):
+        check_error(libfile.capy_shading_set_domain(self, starting, ending))
 
     def __del__(self):
         check_error(libfile.capy_shading_destroy(self))

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1528,6 +1528,20 @@ CAPYPDF_PUBLIC CapyPDF_EC capy_shading_set_extend(CapyPDF_Shading *shade,
     RETNOERR;
 }
 
+CAPYPDF_PUBLIC CapyPDF_EC capy_shading_set_domain(CapyPDF_Shading *shade,
+                                                  double starting,
+                                                  double ending) CAPYPDF_NOEXCEPT {
+    auto *sh = reinterpret_cast<PdfShading *>(shade);
+    if(auto *ptr = std::get_if<ShadingType2>(sh)) {
+        ptr->domain = ShadingDomain{starting, ending};
+    } else if(auto *ptr = std::get_if<ShadingType3>(sh)) {
+        ptr->domain = ShadingDomain{starting, ending};
+    } else {
+        return conv_err(ErrorCode::IncorrectFunctionType);
+    }
+    RETNOERR;
+}
+
 CAPYPDF_PUBLIC CapyPDF_EC capy_shading_destroy(CapyPDF_Shading *shade) CAPYPDF_NOEXCEPT {
     delete reinterpret_cast<PdfShading *>(shade);
     RETNOERR;

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -1358,6 +1358,11 @@ rvoe<FullPDFObject> PdfDocument::serialize_shading(const ShadingType2 &shade) {
                        shade.extend->starting ? "true" : "false",
                        shade.extend->ending ? "true" : "false");
     }
+    if(shade.domain) {
+        auto app = std::back_inserter(buf);
+        std::format_to(
+            app, "  /Domain [ {:f} {:f} ]\n", shade.domain->starting, shade.domain->ending);
+    }
     buf += ">>\n";
     return FullPDFObject{std::move(buf), {}};
 }
@@ -1386,6 +1391,11 @@ rvoe<FullPDFObject> PdfDocument::serialize_shading(const ShadingType3 &shade) {
                        "  /Extend [ {} {} ]\n",
                        shade.extend->starting ? "true" : "false",
                        shade.extend->ending ? "true" : "false");
+    }
+    if(shade.domain) {
+        auto app = std::back_inserter(buf);
+        std::format_to(
+            app, "  /Domain [ {:f} {:f} ]\n", shade.domain->starting, shade.domain->ending);
     }
     buf += ">>\n";
 

--- a/src/drawcontext.cpp
+++ b/src/drawcontext.cpp
@@ -709,9 +709,6 @@ rvoe<NoReturnValue> PdfDrawContext::convert_to_output_cs_and_set_color(const Dev
 }
 
 rvoe<NoReturnValue> PdfDrawContext::set_color(CapyPDF_PatternId id, bool stroke) {
-    if(context_type != CAPY_DC_PAGE) {
-        RETERR(PatternNotAccepted);
-    }
     if(stroke) {
         ERCV(cmd_CS("/Pattern"));
     } else {

--- a/src/pdfcommon.hpp
+++ b/src/pdfcommon.hpp
@@ -363,12 +363,18 @@ struct ShadingExtend {
     bool ending;
 };
 
+struct ShadingDomain {
+    double starting;
+    double ending;
+};
+
 // Linear
 struct ShadingType2 {
     CapyPDF_DeviceColorspace colorspace;
     double x0, y0, x1, y1;
     CapyPDF_FunctionId function;
     std::optional<ShadingExtend> extend;
+    std::optional<ShadingDomain> domain;
 };
 
 // Radial
@@ -377,6 +383,7 @@ struct ShadingType3 {
     double x0, y0, r0, x1, y1, r1;
     CapyPDF_FunctionId function;
     std::optional<ShadingExtend> extend;
+    std::optional<ShadingDomain> domain;
 };
 
 struct ShadingPattern {


### PR DESCRIPTION
Also removes a restriction which limited drawing operations to page contexts, but these are valid instructions for transparency groups too.

There is one question I had for you @jpakkane the PDF specification allows any ColorSpace to be used for a gradient shading pattern / shading function. Not just deviceCMYK / deviceRGB etc. Does capypdf provide the ability to feed an icc profile id into these functions that take a color space enum?