### PR TITLE
Forgive non-color values their tiny errors.

### DIFF
--- a/include/capypdf.hpp
+++ b/include/capypdf.hpp
@@ -400,6 +400,7 @@ public:
     void set_nonstroke(Color &color) { CAPY_CPP_CHECK(capy_dc_set_nonstroke(*this, color)); }
     void set_stroke(Color &color) { CAPY_CPP_CHECK(capy_dc_set_stroke(*this, color)); }
     void cmd_w(double value) { CAPY_CPP_CHECK(capy_dc_cmd_w(*this, value)); }
+    void cmd_n() { CAPY_CPP_CHECK(capy_dc_cmd_n(*this)); }
     void cmd_M(double value) { CAPY_CPP_CHECK(capy_dc_cmd_M(*this, value)); }
     void cmd_j(CapyPDF_Line_Join value) { CAPY_CPP_CHECK(capy_dc_cmd_j(*this, value)); }
     void cmd_J(CapyPDF_Line_Cap value) { CAPY_CPP_CHECK(capy_dc_cmd_J(*this, value)); }

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -125,8 +125,8 @@ rvoe<std::string> serialize_shade4(const ShadingType4 &shade) {
         const char *ptr;
         ptr = (const char *)(&flag);
         s.append(ptr, ptr + sizeof(char));
-        ERCV(append_floatvalue<uint32_t>(s, xratio));
-        ERCV(append_floatvalue<uint32_t>(s, yratio));
+        ERCV(append_floatvalue<uint32_t>(s, std::clamp(xratio, 0.0, 1.0)));
+        ERCV(append_floatvalue<uint32_t>(s, std::clamp(yratio, 0.0, 1.0)));
 
         if(auto *c = std::get_if<DeviceRGBColor>(&e.sp.c)) {
             if(shade.colorspace != CAPY_DEVICE_CS_RGB) {
@@ -174,8 +174,8 @@ rvoe<std::string> serialize_shade6(const ShadingType6 &shade) {
             double xratio = (p.x - shade.minx) / (shade.maxx - shade.minx);
             double yratio = (p.y - shade.miny) / (shade.maxy - shade.miny);
 
-            ERCV(append_floatvalue<uint32_t>(s, xratio));
-            ERCV(append_floatvalue<uint32_t>(s, yratio));
+            ERCV(append_floatvalue<uint32_t>(s, std::clamp(xratio, 0.0, 1.0)));
+            ERCV(append_floatvalue<uint32_t>(s, std::clamp(yratio, 0.0, 1.0)));
         }
         for(const auto &colorobj : e.c) {
             if(shade.colorspace == CAPY_DEVICE_CS_RGB) {


### PR DESCRIPTION
I was having problems making mesh gradients, with ratiox and ratioy values turning in `-6.1343 e-8` (A tiny negative value)

The error message was unhelpful because the problem wasn't colors, it was ratios, but it looks like that code got reused and the same error message was used.

This MR adds a clamp, this helps fix everything.