### PR TITLE
Rename Metadata class to Properties.

### DIFF
--- a/devtools/hbtest.cpp
+++ b/devtools/hbtest.cpp
@@ -145,7 +145,7 @@ void do_harfbuzz(PdfDrawContext &ctx, CapyPDF_FontId pdffont) {
 }
 
 void hardcoded() {
-    DocumentMetadata opts;
+    DocumentProperties opts;
     opts.lang = asciistring::from_cstr("en-US").value();
     GenPopper genpop("shapedtext.pdf", opts);
     PdfGen &gen = *genpop.g;
@@ -169,7 +169,7 @@ void hardcoded() {
 }
 
 void hardcoded2() {
-    DocumentMetadata opts;
+    DocumentProperties opts;
     opts.default_page_properties.mediabox = PdfRectangle(0, 0, 200, 200);
     opts.lang = asciistring::from_cstr("en-US").value();
     GenPopper genpop("hbsmallcaps.pdf", opts);
@@ -198,7 +198,7 @@ void hardcoded2() {
 }
 
 void whole_shebang() {
-    DocumentMetadata opts;
+    DocumentProperties opts;
     opts.default_page_properties.mediabox = PdfRectangle(0, 0, 200, 200);
     opts.lang = asciistring::from_cstr("en-US").value();
     GenPopper genpop("harfbuzz.pdf", opts);

--- a/include/capypdf.h.in
+++ b/include/capypdf.h.in
@@ -329,7 +329,7 @@ typedef struct _capyPDF_DrawContext CapyPDF_DrawContext;
 typedef struct _capyPDF_Generator CapyPDF_Generator;
 typedef struct _capyPDF_GraphicsState CapyPDF_GraphicsState;
 typedef struct _capyPDF_OptionalContentGroup CapyPDF_OptionalContentGroup;
-typedef struct _capyPDF_DocumentMetadata CapyPDF_DocumentMetadata;
+typedef struct _capyPDF_DocumentProperties CapyPDF_DocumentProperties;
 typedef struct _capyPDF_PageProperties CapyPDF_PageProperties;
 typedef struct _capyPDF_Text CapyPDF_Text;
 typedef struct _capyPDF_TextSequence CapyPDF_TextSequence;
@@ -427,49 +427,54 @@ typedef struct {
 
 // Options
 
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_new(CapyPDF_DocumentMetadata **out_ptr) CAPYPDF_NOEXCEPT;
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_destroy(CapyPDF_DocumentMetadata *md) CAPYPDF_NOEXCEPT;
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_title(CapyPDF_DocumentMetadata *md,
-                                                const char *utf8_title) CAPYPDF_NOEXCEPT;
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_author(CapyPDF_DocumentMetadata *md,
-                                                 const char *utf8_author) CAPYPDF_NOEXCEPT;
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_creator(CapyPDF_DocumentMetadata *md,
-                                                  const char *utf8_creator) CAPYPDF_NOEXCEPT;
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_language(CapyPDF_DocumentMetadata *md,
-                                                   const char *lang) CAPYPDF_NOEXCEPT;
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_device_profile(CapyPDF_DocumentMetadata *md,
-                                                         CapyPDF_DeviceColorspace cs,
-                                                         const char *profile_path) CAPYPDF_NOEXCEPT;
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_colorspace(CapyPDF_DocumentMetadata *md,
-                                                     CapyPDF_DeviceColorspace cs) CAPYPDF_NOEXCEPT;
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_output_intent(CapyPDF_DocumentMetadata *md,
-                                                        const char *identifier) CAPYPDF_NOEXCEPT;
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_pdfx(CapyPDF_DocumentMetadata *md,
-                                               CapyPDF_PDFX_Type xtype) CAPYPDF_NOEXCEPT;
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_pdfa(CapyPDF_DocumentMetadata *md,
-                                               CapyPDF_PDFA_Type atype) CAPYPDF_NOEXCEPT;
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_default_page_properties(
-    CapyPDF_DocumentMetadata *md, const CapyPDF_PageProperties *prop) CAPYPDF_NOEXCEPT;
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_tagged(CapyPDF_DocumentMetadata *md,
-                                                 int32_t is_tagged) CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_document_properties_new(CapyPDF_DocumentProperties **out_ptr)
+    CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_document_properties_destroy(CapyPDF_DocumentProperties *docprops)
+    CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_document_properties_set_title(
+    CapyPDF_DocumentProperties *docprops, const char *utf8_title) CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_document_properties_set_author(
+    CapyPDF_DocumentProperties *docprops, const char *utf8_author) CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_document_properties_set_creator(
+    CapyPDF_DocumentProperties *docprops, const char *utf8_creator) CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_document_properties_set_language(
+    CapyPDF_DocumentProperties *docprops, const char *lang) CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC
+capy_document_properties_set_device_profile(CapyPDF_DocumentProperties *docprops,
+                                            CapyPDF_DeviceColorspace cs,
+                                            const char *profile_path) CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_document_properties_set_colorspace(
+    CapyPDF_DocumentProperties *docprops, CapyPDF_DeviceColorspace cs) CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_document_properties_set_output_intent(
+    CapyPDF_DocumentProperties *docprops, const char *identifier) CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_document_properties_set_pdfx(
+    CapyPDF_DocumentProperties *docprops, CapyPDF_PDFX_Type xtype) CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_document_properties_set_pdfa(
+    CapyPDF_DocumentProperties *docprops, CapyPDF_PDFA_Type atype) CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_document_properties_set_default_page_properties(
+    CapyPDF_DocumentProperties *docprops, const CapyPDF_PageProperties *prop) CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_document_properties_set_tagged(CapyPDF_DocumentProperties *docprops,
+                                                              int32_t is_tagged) CAPYPDF_NOEXCEPT;
 
 // Page properties.
 CAPYPDF_PUBLIC CapyPDF_EC capy_page_properties_new(CapyPDF_PageProperties **out_ptr)
     CAPYPDF_NOEXCEPT;
-CAPYPDF_PUBLIC CapyPDF_EC capy_page_properties_destroy(CapyPDF_PageProperties *) CAPYPDF_NOEXCEPT;
-CAPYPDF_PUBLIC CapyPDF_EC capy_page_properties_set_pagebox(CapyPDF_PageProperties *prop,
+CAPYPDF_PUBLIC CapyPDF_EC capy_page_properties_destroy(CapyPDF_PageProperties *pageprops)
+    CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_page_properties_set_pagebox(CapyPDF_PageProperties *pageprops,
                                                            CapyPDF_Page_Box boxtype,
                                                            double x1,
                                                            double y1,
                                                            double x2,
                                                            double y2) CAPYPDF_NOEXCEPT;
 CAPYPDF_PUBLIC CapyPDF_EC capy_page_properties_set_transparency_group_properties(
-    CapyPDF_PageProperties *pageprop, CapyPDF_TransparencyGroupProperties *trprop) CAPYPDF_NOEXCEPT;
+    CapyPDF_PageProperties *pageprops,
+    CapyPDF_TransparencyGroupProperties *trprop) CAPYPDF_NOEXCEPT;
 
 // Generator
 
 CAPYPDF_PUBLIC CapyPDF_EC capy_generator_new(const char *filename,
-                                             const CapyPDF_DocumentMetadata *md,
+                                             const CapyPDF_DocumentProperties *docprops,
                                              CapyPDF_Generator **out_ptr) CAPYPDF_NOEXCEPT;
 CAPYPDF_PUBLIC CapyPDF_EC capy_generator_add_page(CapyPDF_Generator *g,
                                                   CapyPDF_DrawContext *ctx) CAPYPDF_NOEXCEPT;

--- a/include/capypdf.hpp
+++ b/include/capypdf.hpp
@@ -29,8 +29,8 @@ public:
 struct CapyCTypeDeleter {
     template<typename T> void operator()(T *cobj) {
         int32_t rc;
-        if constexpr(std::is_same_v<T, CapyPDF_DocumentMetadata>) {
-            rc = capy_doc_md_destroy(cobj);
+        if constexpr(std::is_same_v<T, CapyPDF_DocumentProperties>) {
+            rc = capy_document_properties_destroy(cobj);
         } else if constexpr(std::is_same_v<T, CapyPDF_PageProperties>) {
             rc = capy_page_properties_destroy(cobj);
         } else if constexpr(std::is_same_v<T, CapyPDF_TextSequence>) {
@@ -58,7 +58,7 @@ struct CapyCTypeDeleter {
         } else if constexpr(std::is_same_v<T, CapyPDF_Generator>) {
             rc = capy_generator_destroy(cobj);
         } else {
-            static_assert(std::is_same_v<T, CapyPDF_DocumentMetadata>, "Unknown C object type.");
+            static_assert(std::is_same_v<T, CapyPDF_DocumentProperties>, "Unknown C object type.");
         }
         (void)rc; // Not much we can do about this because destructors should not fail or throw.
     }
@@ -72,17 +72,17 @@ protected:
     std::unique_ptr<T, CapyCTypeDeleter> _d;
 };
 
-class DocumentMetadata : public CapyC<CapyPDF_DocumentMetadata> {
+class DocumentProperties : public CapyC<CapyPDF_DocumentProperties> {
 public:
     friend class Generator;
 
-    DocumentMetadata() {
-        CapyPDF_DocumentMetadata *md;
-        CAPY_CPP_CHECK(capy_doc_md_new(&md));
-        _d.reset(md);
+    DocumentProperties() {
+        CapyPDF_DocumentProperties *dp;
+        CAPY_CPP_CHECK(capy_document_properties_new(&dp));
+        _d.reset(dp);
     }
 };
-static_assert(sizeof(DocumentMetadata) == sizeof(void *));
+static_assert(sizeof(DocumentProperties) == sizeof(void *));
 
 class TransparencyGroupProperties : public CapyC<CapyPDF_TransparencyGroupProperties> {
 public:
@@ -470,7 +470,7 @@ public:
 
 class Generator : public CapyC<CapyPDF_Generator> {
 public:
-    Generator(const char *filename, const DocumentMetadata &md) {
+    Generator(const char *filename, const DocumentProperties &md) {
         CapyPDF_Generator *gen;
         CAPY_CPP_CHECK(capy_generator_new(filename, md, &gen));
         _d.reset(gen);

--- a/python/capypdf.py
+++ b/python/capypdf.py
@@ -279,19 +279,19 @@ class RoleId(ctypes.Structure):
 
 cfunc_types = (
 
-('capy_doc_md_new', [ctypes.c_void_p]),
-('capy_doc_md_destroy', [ctypes.c_void_p]),
-('capy_doc_md_set_colorspace', [ctypes.c_void_p, enum_type]),
-('capy_doc_md_set_device_profile', [ctypes.c_void_p, enum_type, ctypes.c_char_p]),
-('capy_doc_md_set_title', [ctypes.c_void_p, ctypes.c_char_p]),
-('capy_doc_md_set_author', [ctypes.c_void_p, ctypes.c_char_p]),
-('capy_doc_md_set_creator', [ctypes.c_void_p, ctypes.c_char_p]),
-('capy_doc_md_set_language', [ctypes.c_void_p, ctypes.c_char_p]),
-('capy_doc_md_set_output_intent', [ctypes.c_void_p, ctypes.c_char_p]),
-('capy_doc_md_set_pdfx', [ctypes.c_void_p, enum_type]),
-('capy_doc_md_set_pdfa', [ctypes.c_void_p, enum_type]),
-('capy_doc_md_set_default_page_properties', [ctypes.c_void_p, ctypes.c_void_p]),
-('capy_doc_md_set_tagged', [ctypes.c_void_p, ctypes.c_int32]),
+('capy_document_properties_new', [ctypes.c_void_p]),
+('capy_document_properties_destroy', [ctypes.c_void_p]),
+('capy_document_properties_set_colorspace', [ctypes.c_void_p, enum_type]),
+('capy_document_properties_set_device_profile', [ctypes.c_void_p, enum_type, ctypes.c_char_p]),
+('capy_document_properties_set_title', [ctypes.c_void_p, ctypes.c_char_p]),
+('capy_document_properties_set_author', [ctypes.c_void_p, ctypes.c_char_p]),
+('capy_document_properties_set_creator', [ctypes.c_void_p, ctypes.c_char_p]),
+('capy_document_properties_set_language', [ctypes.c_void_p, ctypes.c_char_p]),
+('capy_document_properties_set_output_intent', [ctypes.c_void_p, ctypes.c_char_p]),
+('capy_document_properties_set_pdfx', [ctypes.c_void_p, enum_type]),
+('capy_document_properties_set_pdfa', [ctypes.c_void_p, enum_type]),
+('capy_document_properties_set_default_page_properties', [ctypes.c_void_p, ctypes.c_void_p]),
+('capy_document_properties_set_tagged', [ctypes.c_void_p, ctypes.c_int32]),
 
 ('capy_page_properties_new', [ctypes.c_void_p]),
 ('capy_page_properties_destroy', [ctypes.c_void_p]),
@@ -631,64 +631,64 @@ def to_array(ctype, array):
         raise CapyPDFException('Array value argument must be an list or tuple.')
     return (ctype * len(array))(*array), len(array)
 
-class DocumentMetadata:
+class DocumentProperties:
     def __init__(self):
-        opt = ctypes.c_void_p()
-        check_error(libfile.capy_doc_md_new(ctypes.pointer(opt)))
-        self._as_parameter_ = opt
+        prop = ctypes.c_void_p()
+        check_error(libfile.capy_document_properties_new(ctypes.pointer(prop)))
+        self._as_parameter_ = prop
 
     def __del__(self):
-        check_error(libfile.capy_doc_md_destroy(self))
+        check_error(libfile.capy_document_properties_destroy(self))
 
     def set_colorspace(self, cs):
         if not isinstance(cs, DeviceColorspace):
             raise CapyPDFException('Argument not a device colorspace object.')
-        check_error(libfile.capy_doc_md_set_colorspace(self, cs.value))
+        check_error(libfile.capy_document_properties_set_colorspace(self, cs.value))
 
     def set_title(self, title):
         if not isinstance(title, str):
             raise CapyPDFException('Title must be an Unicode string.')
-        check_error(libfile.capy_doc_md_set_title(self, title.encode('UTF-8')))
+        check_error(libfile.capy_document_properties_set_title(self, title.encode('UTF-8')))
 
     def set_author(self, author):
         if not isinstance(author, str):
             raise CapyPDFException('Author must be an Unicode string.')
-        check_error(libfile.capy_doc_md_set_author(self, author.encode('UTF-8')))
+        check_error(libfile.capy_document_properties_set_author(self, author.encode('UTF-8')))
 
     def set_creator(self, creator):
         if not isinstance(creator, str):
             raise CapyPDFException('Creator must be an Unicode string.')
-        check_error(libfile.capy_doc_md_set_creator(self, creator.encode('UTF-8')))
+        check_error(libfile.capy_document_properties_set_creator(self, creator.encode('UTF-8')))
 
     def set_language(self, lang):
         if not isinstance(lang, str):
             raise CapyPDFException('Creator must be an Unicode string.')
-        check_error(libfile.capy_doc_md_set_language(self, lang.encode('ASCII')))
+        check_error(libfile.capy_document_properties_set_language(self, lang.encode('ASCII')))
 
     def set_device_profile(self, colorspace, path):
-        check_error(libfile.capy_doc_md_set_device_profile(self, colorspace.value, to_bytepath(path)))
+        check_error(libfile.capy_document_properties_set_device_profile(self, colorspace.value, to_bytepath(path)))
 
     def set_output_intent(self, identifier):
-        check_error(libfile.capy_doc_md_set_output_intent(self, identifier.encode('utf-8')))
+        check_error(libfile.capy_document_properties_set_output_intent(self, identifier.encode('utf-8')))
 
     def set_pdfx(self, xtype):
         if not isinstance(xtype, PdfXType):
             raise CapyPDFException('Argument must be an PDF/X type.')
-        check_error(libfile.capy_doc_md_set_pdfx(self, xtype.value))
+        check_error(libfile.capy_document_properties_set_pdfx(self, xtype.value))
 
     def set_pdfa(self, atype):
         if not isinstance(atype, PdfAType):
             raise CapyPDFException('Argument must be an PDF/A type.')
-        check_error(libfile.capy_doc_md_set_pdfa(self, atype.value))
+        check_error(libfile.capy_document_properties_set_pdfa(self, atype.value))
 
     def set_default_page_properties(self, props):
         if not isinstance(props, PageProperties):
             raise CapyPDFException('Argument is not a PageProperties object.')
-        check_error(libfile.capy_doc_md_set_default_page_properties(self, props))
+        check_error(libfile.capy_document_properties_set_default_page_properties(self, props))
 
     def set_tagged(self, is_tagged):
         tagint = 1 if is_tagged else 0
-        check_error(libfile.capy_doc_md_set_tagged(self, tagint))
+        check_error(libfile.capy_document_properties_set_tagged(self, tagint))
 
 
 class PageProperties:
@@ -1022,7 +1022,7 @@ class Generator:
     def __init__(self, filename, options=None):
         file_name_bytes = to_bytepath(filename)
         if options is None:
-            options = DocumentMetadata()
+            options = DocumentProperties()
         gptr = ctypes.c_void_p()
         check_error(libfile.capy_generator_new(file_name_bytes, options, ctypes.pointer(gptr)))
         self._as_parameter_ = gptr

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -26,48 +26,48 @@ template<typename T> CapyPDF_EC conv_err(const rvoe<T> &rc) {
 
 } // namespace
 
-CapyPDF_EC capy_doc_md_new(CapyPDF_DocumentMetadata **out_ptr) CAPYPDF_NOEXCEPT {
-    *out_ptr = reinterpret_cast<CapyPDF_DocumentMetadata *>(new DocumentMetadata());
+CapyPDF_EC capy_document_properties_new(CapyPDF_DocumentProperties **out_ptr) CAPYPDF_NOEXCEPT {
+    *out_ptr = reinterpret_cast<CapyPDF_DocumentProperties *>(new DocumentProperties());
     RETNOERR;
 }
 
-CapyPDF_EC capy_doc_md_destroy(CapyPDF_DocumentMetadata *md) CAPYPDF_NOEXCEPT {
-    delete reinterpret_cast<DocumentMetadata *>(md);
+CapyPDF_EC capy_document_properties_destroy(CapyPDF_DocumentProperties *docprops) CAPYPDF_NOEXCEPT {
+    delete reinterpret_cast<DocumentProperties *>(docprops);
     RETNOERR;
 }
 
-CapyPDF_EC capy_doc_md_set_title(CapyPDF_DocumentMetadata *md,
-                                 const char *utf8_title) CAPYPDF_NOEXCEPT {
+CapyPDF_EC capy_document_properties_set_title(CapyPDF_DocumentProperties *docprops,
+                                              const char *utf8_title) CAPYPDF_NOEXCEPT {
     auto rc = u8string::from_cstr(utf8_title);
     if(rc) {
-        reinterpret_cast<DocumentMetadata *>(md)->title = std::move(rc.value());
+        reinterpret_cast<DocumentProperties *>(docprops)->title = std::move(rc.value());
     }
     return conv_err(rc);
 }
 
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_author(CapyPDF_DocumentMetadata *md,
-                                                 const char *utf8_author) CAPYPDF_NOEXCEPT {
+CAPYPDF_PUBLIC CapyPDF_EC capy_document_properties_set_author(
+    CapyPDF_DocumentProperties *docprops, const char *utf8_author) CAPYPDF_NOEXCEPT {
     auto rc = u8string::from_cstr(utf8_author);
     if(rc) {
-        reinterpret_cast<DocumentMetadata *>(md)->author = std::move(rc.value());
+        reinterpret_cast<DocumentProperties *>(docprops)->author = std::move(rc.value());
     }
     return conv_err(rc);
 }
 
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_creator(CapyPDF_DocumentMetadata *md,
-                                                  const char *utf8_creator) CAPYPDF_NOEXCEPT {
+CAPYPDF_PUBLIC CapyPDF_EC capy_document_properties_set_creator(
+    CapyPDF_DocumentProperties *docprops, const char *utf8_creator) CAPYPDF_NOEXCEPT {
     auto rc = u8string::from_cstr(utf8_creator);
     if(rc) {
-        reinterpret_cast<DocumentMetadata *>(md)->creator = std::move(rc.value());
+        reinterpret_cast<DocumentProperties *>(docprops)->creator = std::move(rc.value());
     }
     return conv_err(rc);
 }
 
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_language(CapyPDF_DocumentMetadata *md,
-                                                   const char *lang) CAPYPDF_NOEXCEPT {
+CAPYPDF_PUBLIC CapyPDF_EC capy_document_properties_set_language(
+    CapyPDF_DocumentProperties *docprops, const char *lang) CAPYPDF_NOEXCEPT {
     auto rc = asciistring::from_cstr(lang);
     if(rc) {
-        reinterpret_cast<DocumentMetadata *>(md)->lang = std::move(rc.value());
+        reinterpret_cast<DocumentProperties *>(docprops)->lang = std::move(rc.value());
     }
     return conv_err(rc);
 }
@@ -78,19 +78,19 @@ CAPYPDF_PUBLIC CapyPDF_EC capy_page_properties_new(CapyPDF_PageProperties **out_
     RETNOERR;
 }
 
-CAPYPDF_PUBLIC CapyPDF_EC capy_page_properties_destroy(CapyPDF_PageProperties *prop)
+CAPYPDF_PUBLIC CapyPDF_EC capy_page_properties_destroy(CapyPDF_PageProperties *pageprops)
     CAPYPDF_NOEXCEPT {
-    delete reinterpret_cast<PageProperties *>(prop);
+    delete reinterpret_cast<PageProperties *>(pageprops);
     RETNOERR;
 }
 
-CAPYPDF_PUBLIC CapyPDF_EC capy_page_properties_set_pagebox(CapyPDF_PageProperties *prop,
+CAPYPDF_PUBLIC CapyPDF_EC capy_page_properties_set_pagebox(CapyPDF_PageProperties *pageprops,
                                                            CapyPDF_Page_Box boxtype,
                                                            double x1,
                                                            double y1,
                                                            double x2,
                                                            double y2) CAPYPDF_NOEXCEPT {
-    auto props = reinterpret_cast<PageProperties *>(prop);
+    auto props = reinterpret_cast<PageProperties *>(pageprops);
     switch(boxtype) {
     case CAPY_BOX_MEDIA:
         props->mediabox = PdfRectangle{x1, y1, x2, y2};
@@ -115,19 +115,19 @@ CAPYPDF_PUBLIC CapyPDF_EC capy_page_properties_set_pagebox(CapyPDF_PagePropertie
 }
 
 CAPYPDF_PUBLIC CapyPDF_EC capy_page_properties_set_transparency_group_properties(
-    CapyPDF_PageProperties *pageprop,
+    CapyPDF_PageProperties *pageprops,
     CapyPDF_TransparencyGroupProperties *trprop) CAPYPDF_NOEXCEPT {
-    auto *page = reinterpret_cast<PageProperties *>(pageprop);
+    auto *page = reinterpret_cast<PageProperties *>(pageprops);
     auto *tr = reinterpret_cast<TransparencyGroupProperties *>(trprop);
     page->transparency_props = *tr;
     RETNOERR;
 }
 
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_device_profile(CapyPDF_DocumentMetadata *md,
-                                                         CapyPDF_DeviceColorspace cs,
-                                                         const char *profile_path)
-    CAPYPDF_NOEXCEPT {
-    auto metadata = reinterpret_cast<DocumentMetadata *>(md);
+CAPYPDF_PUBLIC CapyPDF_EC
+capy_document_properties_set_device_profile(CapyPDF_DocumentProperties *docprops,
+                                            CapyPDF_DeviceColorspace cs,
+                                            const char *profile_path) CAPYPDF_NOEXCEPT {
+    auto metadata = reinterpret_cast<DocumentProperties *>(docprops);
     switch(cs) {
     case CAPY_DEVICE_CS_RGB:
         metadata->prof.rgb_profile_file = profile_path;
@@ -142,37 +142,37 @@ CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_device_profile(CapyPDF_DocumentMetadat
     RETNOERR;
 }
 
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_colorspace(CapyPDF_DocumentMetadata *md,
-                                                     CapyPDF_DeviceColorspace cs) CAPYPDF_NOEXCEPT {
-    auto metadata = reinterpret_cast<DocumentMetadata *>(md);
+CAPYPDF_PUBLIC CapyPDF_EC capy_document_properties_set_colorspace(
+    CapyPDF_DocumentProperties *docprops, CapyPDF_DeviceColorspace cs) CAPYPDF_NOEXCEPT {
+    auto metadata = reinterpret_cast<DocumentProperties *>(docprops);
     metadata->output_colorspace = cs;
     RETNOERR;
 }
 
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_output_intent(CapyPDF_DocumentMetadata *md,
-                                                        const char *identifier) CAPYPDF_NOEXCEPT {
+CAPYPDF_PUBLIC CapyPDF_EC capy_document_properties_set_output_intent(
+    CapyPDF_DocumentProperties *docprops, const char *identifier) CAPYPDF_NOEXCEPT {
     CHECK_NULL(identifier);
-    auto metadata = reinterpret_cast<DocumentMetadata *>(md);
+    auto metadata = reinterpret_cast<DocumentProperties *>(docprops);
     metadata->intent_condition_identifier = identifier;
     RETNOERR;
 }
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_pdfx(CapyPDF_DocumentMetadata *md,
-                                               CapyPDF_PDFX_Type xtype) CAPYPDF_NOEXCEPT {
-    auto metadata = reinterpret_cast<DocumentMetadata *>(md);
+CAPYPDF_PUBLIC CapyPDF_EC capy_document_properties_set_pdfx(
+    CapyPDF_DocumentProperties *docprops, CapyPDF_PDFX_Type xtype) CAPYPDF_NOEXCEPT {
+    auto metadata = reinterpret_cast<DocumentProperties *>(docprops);
     metadata->subtype = xtype;
     RETNOERR;
 }
 
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_pdfa(CapyPDF_DocumentMetadata *md,
-                                               CapyPDF_PDFA_Type atype) CAPYPDF_NOEXCEPT {
-    auto metadata = reinterpret_cast<DocumentMetadata *>(md);
+CAPYPDF_PUBLIC CapyPDF_EC capy_document_properties_set_pdfa(
+    CapyPDF_DocumentProperties *docprops, CapyPDF_PDFA_Type atype) CAPYPDF_NOEXCEPT {
+    auto metadata = reinterpret_cast<DocumentProperties *>(docprops);
     metadata->subtype = atype;
     RETNOERR;
 }
 
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_default_page_properties(
-    CapyPDF_DocumentMetadata *md, const CapyPDF_PageProperties *prop) CAPYPDF_NOEXCEPT {
-    auto metadata = reinterpret_cast<DocumentMetadata *>(md);
+CAPYPDF_PUBLIC CapyPDF_EC capy_document_properties_set_default_page_properties(
+    CapyPDF_DocumentProperties *docprops, const CapyPDF_PageProperties *prop) CAPYPDF_NOEXCEPT {
+    auto metadata = reinterpret_cast<DocumentProperties *>(docprops);
     auto props = reinterpret_cast<const PageProperties *>(prop);
     if(!props->mediabox) {
         return conv_err(ErrorCode::MissingMediabox);
@@ -181,21 +181,21 @@ CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_default_page_properties(
     RETNOERR;
 }
 
-CAPYPDF_PUBLIC CapyPDF_EC capy_doc_md_set_tagged(CapyPDF_DocumentMetadata *md,
-                                                 int32_t is_tagged) CAPYPDF_NOEXCEPT {
+CAPYPDF_PUBLIC CapyPDF_EC capy_document_properties_set_tagged(CapyPDF_DocumentProperties *docprops,
+                                                              int32_t is_tagged) CAPYPDF_NOEXCEPT {
     CHECK_BOOLEAN(is_tagged);
-    auto metadata = reinterpret_cast<DocumentMetadata *>(md);
+    auto metadata = reinterpret_cast<DocumentProperties *>(docprops);
     metadata->is_tagged = is_tagged;
     RETNOERR;
 }
 
 CapyPDF_EC capy_generator_new(const char *filename,
-                              const CapyPDF_DocumentMetadata *md,
+                              const CapyPDF_DocumentProperties *docprops,
                               CapyPDF_Generator **out_ptr) CAPYPDF_NOEXCEPT {
     CHECK_NULL(filename);
-    CHECK_NULL(md);
+    CHECK_NULL(docprops);
     CHECK_NULL(out_ptr);
-    auto metadata = reinterpret_cast<const DocumentMetadata *>(md);
+    auto metadata = reinterpret_cast<const DocumentProperties *>(docprops);
     auto rc = PdfGen::construct(filename, *metadata);
     if(rc) {
         *out_ptr = reinterpret_cast<CapyPDF_Generator *>(rc.value().release());

--- a/src/document.hpp
+++ b/src/document.hpp
@@ -171,8 +171,8 @@ struct IccInfo {
     int32_t num_channels;
 };
 
-struct DocumentMetadata {
-    DocumentMetadata() { default_page_properties.mediabox = PdfRectangle::a4(); }
+struct DocumentProperties {
+    DocumentProperties() { default_page_properties.mediabox = PdfRectangle::a4(); }
 
     PageProperties default_page_properties;
     u8string title;
@@ -328,7 +328,7 @@ typedef std::variant<CapyPDF_ImageColorspace, CapyPDF_IccColorSpaceId> ImageColo
 
 class PdfDocument {
 public:
-    static rvoe<PdfDocument> construct(const DocumentMetadata &d, PdfColorConverter cm);
+    static rvoe<PdfDocument> construct(const DocumentProperties &d, PdfColorConverter cm);
 
     PdfDocument(PdfDocument &&o) = default;
 
@@ -434,7 +434,7 @@ public:
     rvoe<CapyPDF_RoleId> add_rolemap_entry(std::string name, CapyPDF_StructureType builtin_type);
 
 private:
-    PdfDocument(const DocumentMetadata &d, PdfColorConverter cm);
+    PdfDocument(const DocumentProperties &d, PdfColorConverter cm);
     rvoe<NoReturnValue> init();
 
     int32_t add_object(ObjectType object);
@@ -487,7 +487,7 @@ private:
     FontInfo &get(CapyPDF_FontId id) { return font_objects.at(id.id); }
     const FontInfo &get(CapyPDF_FontId id) const { return font_objects.at(id.id); }
 
-    DocumentMetadata opts;
+    DocumentProperties docprops;
     PdfColorConverter cm;
     std::vector<ObjectType> document_objects;
     std::vector<PageOffsets> pages; // Refers to object num.

--- a/src/drawcontext.cpp
+++ b/src/drawcontext.cpp
@@ -650,7 +650,7 @@ rvoe<NoReturnValue> PdfDrawContext::set_color(const Color &c, bool stroke) {
 
 rvoe<NoReturnValue> PdfDrawContext::convert_to_output_cs_and_set_color(const DeviceRGBColor &c,
                                                                        bool stroke) {
-    switch(doc->opts.output_colorspace) {
+    switch(doc->docprops.output_colorspace) {
     case CAPY_DEVICE_CS_RGB: {
         return set_color(c, stroke);
     }
@@ -692,7 +692,7 @@ rvoe<NoReturnValue> PdfDrawContext::set_color(const DeviceCMYKColor &c, bool str
 
 rvoe<NoReturnValue> PdfDrawContext::convert_to_output_cs_and_set_color(const DeviceCMYKColor &c,
                                                                        bool stroke) {
-    switch(doc->opts.output_colorspace) {
+    switch(doc->docprops.output_colorspace) {
     case CAPY_DEVICE_CS_RGB: {
         ERC(rgb, cm->to_rgb(c));
         return set_color(rgb, stroke);
@@ -1137,7 +1137,7 @@ rvoe<NoReturnValue> PdfDrawContext::render_pdfdoc_text_builtin(const char *pdfdo
                                                                double pointsize,
                                                                double x,
                                                                double y) {
-    if(!std::holds_alternative<std::monostate>(doc->opts.subtype)) {
+    if(!std::holds_alternative<std::monostate>(doc->docprops.subtype)) {
         RETERR(BadOperationForIntent);
     }
     auto font_object = doc->font_object_number(doc->get_builtin_font_id(font_id));

--- a/src/fembedtest.cpp
+++ b/src/fembedtest.cpp
@@ -7,7 +7,7 @@
 using namespace capypdf::internal;
 
 void file_embed() {
-    DocumentMetadata opts;
+    DocumentProperties opts;
 
     opts.default_page_properties.mediabox->x2 = opts.default_page_properties.mediabox->y2 = 200;
     opts.title = u8string::from_cstr("File embedding test").value();
@@ -48,7 +48,7 @@ void file_embed() {
 }
 
 void video_player() {
-    DocumentMetadata opts;
+    DocumentProperties opts;
 
     opts.default_page_properties.mediabox->x2 = opts.default_page_properties.mediabox->y2 = 200;
     opts.title = u8string::from_cstr("Video player test").value();

--- a/src/fontgen.cpp
+++ b/src/fontgen.cpp
@@ -10,7 +10,7 @@ using namespace capypdf::internal;
 void center_test() {
     u8string text = u8string::from_cstr("Centered text!").value();
     const double pt = 12;
-    DocumentMetadata opts;
+    DocumentProperties opts;
     opts.output_colorspace = CAPY_DEVICE_CS_GRAY;
     opts.default_page_properties.mediabox->x2 = 200;
     opts.default_page_properties.mediabox->y2 = 200;
@@ -38,7 +38,7 @@ void center_test() {
 }
 
 int test1(int argc, char **argv) {
-    DocumentMetadata opts;
+    DocumentProperties opts;
     opts.output_colorspace = CAPY_DEVICE_CS_RGB;
     const char *regularfont;
     const char *italicfont;
@@ -223,7 +223,7 @@ int test1(int argc, char **argv) {
 }
 
 int test2(int argc, char **argv) {
-    DocumentMetadata opts;
+    DocumentProperties opts;
     opts.output_colorspace = CAPY_DEVICE_CS_RGB;
     const char *regularfont;
     if(argc > 1) {

--- a/src/formtest.cpp
+++ b/src/formtest.cpp
@@ -7,7 +7,7 @@
 using namespace capypdf::internal;
 
 int draw_simple_form() {
-    DocumentMetadata opts;
+    DocumentProperties opts;
 
     opts.default_page_properties.mediabox->x2 = opts.default_page_properties.mediabox->y2 = 200;
     opts.title = u8string::from_cstr("Form XObject test").value();
@@ -109,7 +109,7 @@ void draw_circles(PdfDrawContext &ctx, CapyPDF_GraphicsStateId gsid) {
 
 int draw_group_doc() {
     // PDF 2.0 spec page 409.
-    DocumentMetadata opts;
+    DocumentProperties opts;
 
     opts.default_page_properties.mediabox->x2 = 200;
     opts.default_page_properties.mediabox->y2 = 200;
@@ -150,7 +150,7 @@ int draw_group_doc() {
 
 int draw_transp_doc() {
     // PDF 2.0 spec page 409.
-    DocumentMetadata opts;
+    DocumentProperties opts;
     const char *icc_out =
         "/home/jpakkane/Downloads/temp/Adobe ICC Profiles (end-user)/CMYK/UncoatedFOGRA29.icc";
 

--- a/src/generator.cpp
+++ b/src/generator.cpp
@@ -38,7 +38,7 @@ DrawContextPopper::~DrawContextPopper() {
 }
 
 rvoe<std::unique_ptr<PdfGen>> PdfGen::construct(const std::filesystem::path &ofname,
-                                                const DocumentMetadata &d) {
+                                                const DocumentProperties &d) {
     FT_Library ft_;
     auto error = FT_Init_FreeType(&ft_);
     if(error) {
@@ -141,13 +141,16 @@ rvoe<CapyPDF_PatternId> PdfGen::add_tiling_pattern(PdfDrawContext &ctx) {
 }
 
 DrawContextPopper PdfGen::guarded_page_context() {
-    return DrawContextPopper{
-        this, &pdoc, &pdoc.cm, CAPY_DC_PAGE, pdoc.opts.default_page_properties.mediabox.value()};
+    return DrawContextPopper{this,
+                             &pdoc,
+                             &pdoc.cm,
+                             CAPY_DC_PAGE,
+                             pdoc.docprops.default_page_properties.mediabox.value()};
 }
 
 PdfDrawContext *PdfGen::new_page_draw_context() {
     return new PdfDrawContext{
-        &pdoc, &pdoc.cm, CAPY_DC_PAGE, pdoc.opts.default_page_properties.mediabox.value()};
+        &pdoc, &pdoc.cm, CAPY_DC_PAGE, pdoc.docprops.default_page_properties.mediabox.value()};
 }
 
 PdfDrawContext PdfGen::new_color_pattern_builder(const PdfRectangle &rect) {

--- a/src/generator.hpp
+++ b/src/generator.hpp
@@ -37,7 +37,7 @@ struct DrawContextPopper {
 class PdfGen {
 public:
     static rvoe<std::unique_ptr<PdfGen>> construct(const std::filesystem::path &ofname,
-                                                   const DocumentMetadata &d);
+                                                   const DocumentProperties &d);
     PdfGen(PdfGen &&o) = default;
     ~PdfGen();
 
@@ -170,7 +170,7 @@ private:
 
 struct GenPopper {
     std::unique_ptr<PdfGen> g;
-    GenPopper(const std::filesystem::path &ofname, const DocumentMetadata &d) : g() {
+    GenPopper(const std::filesystem::path &ofname, const DocumentProperties &d) : g() {
         auto rc = PdfGen::construct(ofname, d);
         if(!rc) {
             fprintf(stderr, "%s\n", error_text(rc.error()));

--- a/src/loremipsum.cpp
+++ b/src/loremipsum.cpp
@@ -244,7 +244,7 @@ void draw_email(PdfGen &gen, PdfDrawContext &ctx) {
 }
 
 int create_doc() {
-    DocumentMetadata opts;
+    DocumentProperties opts;
     opts.is_tagged = true;
     opts.lang = asciistring::from_cstr("en-US").value();
     opts.subtype = CAPY_PDFA_2b;

--- a/src/pdfwriter.cpp
+++ b/src/pdfwriter.cpp
@@ -498,11 +498,11 @@ rvoe<NoReturnValue> PdfWriter::write_delayed_page(const DelayedPage &dp) {
     if(dp.custom_props.transparency_props) {
         buf += "  /Group ";
         dp.custom_props.transparency_props->serialize(buf_append, "  ");
-    } else if(doc.opts.default_page_properties.transparency_props) {
+    } else if(doc.docprops.default_page_properties.transparency_props) {
         buf += "  /Group ";
-        doc.opts.default_page_properties.transparency_props->serialize(buf_append, "  ");
+        doc.docprops.default_page_properties.transparency_props->serialize(buf_append, "  ");
     }
-    PageProperties current_props = doc.opts.default_page_properties.merge_with(dp.custom_props);
+    PageProperties current_props = doc.docprops.default_page_properties.merge_with(dp.custom_props);
     write_rectangle(buf_append, "MediaBox", *current_props.mediabox);
 
     if(current_props.cropbox) {

--- a/test/capypdftests.py
+++ b/test/capypdftests.py
@@ -111,12 +111,12 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_text', 400, 400)
     def test_text(self, ofilename, w, h):
-        opts = capypdf.DocumentMetadata()
-        props = capypdf.PageProperties()
-        props.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opts.set_default_page_properties(props)
-        opts.set_language('en-US')
-        with capypdf.Generator(ofilename, opts) as g:
+        dprops = capypdf.DocumentProperties()
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops.set_default_page_properties(pprops)
+        dprops.set_language('en-US')
+        with capypdf.Generator(ofilename, dprops) as g:
             fid = g.load_font(noto_fontdir / 'NotoSans-Regular.ttf')
             with g.page_draw_context() as ctx:
                 ctx.render_text('Av, Tv, kerning yo.', fid, 12, 50, 150)
@@ -137,11 +137,11 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_image', 200, 200)
     def test_images(self, ofilename, w, h):
-        opts = capypdf.DocumentMetadata()
-        props = capypdf.PageProperties()
-        props.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opts.set_default_page_properties(props)
-        with capypdf.Generator(ofilename, opts) as g:
+        dprops = capypdf.DocumentProperties()
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops.set_default_page_properties(pprops)
+        with capypdf.Generator(ofilename, dprops) as g:
             params = capypdf.ImagePdfProperties()
             bg_img_ri = g.load_image(image_dir / 'simple.jpg')
             bg_img = g.add_image(bg_img_ri, params)
@@ -172,11 +172,11 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_path', 200, 200)
     def test_path(self, ofilename, w, h):
-        opts = capypdf.DocumentMetadata()
-        props = capypdf.PageProperties()
-        props.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opts.set_default_page_properties(props)
-        with capypdf.Generator(ofilename, opts) as g:
+        dprops = capypdf.DocumentProperties()
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops.set_default_page_properties(pprops)
+        with capypdf.Generator(ofilename, dprops) as g:
             with g.page_draw_context() as ctx:
                 with ctx.push_gstate():
                     ctx.cmd_w(5)
@@ -213,11 +213,11 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_textobj', 200, 200)
     def test_textobj(self, ofilename, w, h):
-        opts = capypdf.DocumentMetadata()
-        props = capypdf.PageProperties()
-        props.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opts.set_default_page_properties(props)
-        with capypdf.Generator(ofilename, opts) as g:
+        dprops = capypdf.DocumentProperties()
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops.set_default_page_properties(pprops)
+        with capypdf.Generator(ofilename, dprops) as g:
             font = g.load_font(noto_fontdir / 'NotoSerif-Regular.ttf')
             with g.page_draw_context() as ctx:
                 t = ctx.text_new()
@@ -228,11 +228,11 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_kerning', 200, 200)
     def test_kerning(self, ofilename, w, h):
-        opts = capypdf.DocumentMetadata()
-        props = capypdf.PageProperties()
-        props.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opts.set_default_page_properties(props)
-        with capypdf.Generator(ofilename, opts) as g:
+        dprops = capypdf.DocumentProperties()
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops.set_default_page_properties(pprops)
+        with capypdf.Generator(ofilename, dprops) as g:
             font = g.load_font(noto_fontdir / 'NotoSerif-Regular.ttf')
             with g.page_draw_context() as ctx:
                 t = ctx.text_new()
@@ -251,11 +251,11 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_shaping', 200, 200)
     def test_shaping(self, ofilename, w, h):
-        opts = capypdf.DocumentMetadata()
-        props = capypdf.PageProperties()
-        props.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opts.set_default_page_properties(props)
-        with capypdf.Generator(ofilename, opts) as g:
+        dprops = capypdf.DocumentProperties()
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops.set_default_page_properties(pprops)
+        with capypdf.Generator(ofilename, dprops) as g:
             font = g.load_font(noto_fontdir / 'NotoSerif-Regular.ttf')
             with g.page_draw_context() as ctx:
                 t = ctx.text_new()
@@ -272,11 +272,11 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_shaping2', 200, 200)
     def test_shaping2(self, ofilename, w, h):
-        opts = capypdf.DocumentMetadata()
-        props = capypdf.PageProperties()
-        props.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opts.set_default_page_properties(props)
-        with capypdf.Generator(ofilename, opts) as g:
+        dprops = capypdf.DocumentProperties()
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops.set_default_page_properties(pprops)
+        with capypdf.Generator(ofilename, dprops) as g:
             font = g.load_font(noto_fontdir / 'NotoSerif-Regular.ttf')
             with g.page_draw_context() as ctx:
                 t = ctx.text_new()
@@ -292,11 +292,11 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_smallcaps', 200, 200)
     def test_smallcaps(self, ofilename, w, h):
-        opts = capypdf.DocumentMetadata()
-        props = capypdf.PageProperties()
-        props.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opts.set_default_page_properties(props)
-        with capypdf.Generator(ofilename, opts) as g:
+        dprops = capypdf.DocumentProperties()
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops.set_default_page_properties(pprops)
+        with capypdf.Generator(ofilename, dprops) as g:
             font = g.load_font(noto_fontdir / 'NotoSerif-Regular.ttf')
             seq = ((54, 'S'),
                    (2200, 'm'),
@@ -322,11 +322,11 @@ class TestPDFCreation(unittest.TestCase):
     @validate_image('python_lab', 200, 200)
     def test_lab(self, ofilename, w, h):
         from math import sin, cos
-        opts = capypdf.DocumentMetadata()
-        props = capypdf.PageProperties()
-        props.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opts.set_default_page_properties(props)
-        with capypdf.Generator(ofilename, opts) as g:
+        dprops = capypdf.DocumentProperties()
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops.set_default_page_properties(pprops)
+        with capypdf.Generator(ofilename, dprops) as g:
             lab = g.add_lab_colorspace(0.9505, 1.0, 1.089, -128, 127, -128, 127)
             with g.page_draw_context() as ctx:
                 ctx.cmd_w(4)
@@ -354,11 +354,11 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_gstate', 200, 200)
     def test_gstate(self, ofilename, w, h):
-        opts = capypdf.DocumentMetadata()
-        props = capypdf.PageProperties()
-        props.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opts.set_default_page_properties(props)
-        with capypdf.Generator(ofilename, opts) as g:
+        dprops = capypdf.DocumentProperties()
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops.set_default_page_properties(pprops)
+        with capypdf.Generator(ofilename, dprops) as g:
             gstate = capypdf.GraphicsState()
             gstate.set_CA(0.1)
             gstate.set_ca(0.5)
@@ -379,11 +379,11 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_icccolor', 200, 200)
     def test_icc(self, ofilename, w, h):
-        opts = capypdf.DocumentMetadata()
-        props = capypdf.PageProperties()
-        props.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opts.set_default_page_properties(props)
-        with capypdf.Generator(ofilename, opts) as g:
+        dprops = capypdf.DocumentProperties()
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops.set_default_page_properties(pprops)
+        with capypdf.Generator(ofilename, dprops) as g:
             cs = g.load_icc_profile('/usr/share/color/icc/ghostscript/a98.icc')
             sc = capypdf.Color()
             sc.set_icc(cs, [0.1, 0.2, 0.8])
@@ -398,11 +398,11 @@ class TestPDFCreation(unittest.TestCase):
 
     @cleanup('transitions.pdf')
     def test_transitions(self, ofilename):
-        opts = capypdf.DocumentMetadata()
-        props = capypdf.PageProperties()
-        props.set_pagebox(capypdf.PageBox.Media, 0, 0, 160, 90)
-        opts.set_default_page_properties(props)
-        with capypdf.Generator(ofilename, opts) as g:
+        dprops = capypdf.DocumentProperties()
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, 160, 90)
+        dprops.set_default_page_properties(pprops)
+        with capypdf.Generator(ofilename, dprops) as g:
             with g.page_draw_context() as ctx:
                 pass
             with g.page_draw_context() as ctx:
@@ -442,11 +442,11 @@ class TestPDFCreation(unittest.TestCase):
     @validate_image('python_rasterimage', 200, 200)
     def test_raster_image(self, ofilename, w, h):
         import zlib
-        opts = capypdf.DocumentMetadata()
-        props = capypdf.PageProperties()
-        props.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opts.set_default_page_properties(props)
-        with capypdf.Generator(ofilename, opts) as g:
+        dprops = capypdf.DocumentProperties()
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops.set_default_page_properties(pprops)
+        with capypdf.Generator(ofilename, dprops) as g:
             ib = capypdf.RasterImageBuilder()
             ib.set_size(2, 3)
             ba = self.build_rasterdata(255)
@@ -472,11 +472,11 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_linestyles', 200, 200)
     def test_line_styles(self, ofilename, w, h):
-        prop = capypdf.PageProperties()
-        prop.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opt = capypdf.DocumentMetadata()
-        opt.set_default_page_properties(prop)
-        with capypdf.Generator(ofilename, opt) as gen:
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops = capypdf.DocumentProperties()
+        dprops.set_default_page_properties(pprops)
+        with capypdf.Generator(ofilename, dprops) as gen:
             with gen.page_draw_context() as ctx:
                 ctx.scale(2.8*2.75, 2.75*2.83)
                 ctx.cmd_cm(1, 0, 0, -1, 0, 25.4)
@@ -635,11 +635,11 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_shading_rgb', 300, 200)
     def test_shading_rgb(self, ofilename, w, h):
-        prop = capypdf.PageProperties()
-        prop.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opt = capypdf.DocumentMetadata()
-        opt.set_default_page_properties(prop)
-        with capypdf.Generator(ofilename, opt) as gen:
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops = capypdf.DocumentProperties()
+        dprops.set_default_page_properties(pprops)
+        with capypdf.Generator(ofilename, dprops) as gen:
             c1 = capypdf.Color()
             c1.set_rgb(0.0, 1.0, 0.0)
             c2 = capypdf.Color()
@@ -729,12 +729,12 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_shading_gray', 200, 200)
     def test_shading_gray(self, ofilename, w, h):
-        prop = capypdf.PageProperties()
-        prop.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opt = capypdf.DocumentMetadata()
-        opt.set_default_page_properties(prop)
-        opt.set_colorspace(capypdf.DeviceColorspace.Gray)
-        with capypdf.Generator(ofilename, opt) as gen:
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops = capypdf.DocumentProperties()
+        dprops.set_default_page_properties(pprops)
+        dprops.set_colorspace(capypdf.DeviceColorspace.Gray)
+        with capypdf.Generator(ofilename, dprops) as gen:
             c1 = capypdf.Color()
             c1.set_gray(0.0)
             c2 = capypdf.Color()
@@ -805,13 +805,13 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_shading_cmyk', 200, 200)
     def test_shading_cmyk(self, ofilename, w, h):
-        prop = capypdf.PageProperties()
-        prop.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opt = capypdf.DocumentMetadata()
-        opt.set_default_page_properties(prop)
-        opt.set_colorspace(capypdf.DeviceColorspace.CMYK)
-        opt.set_device_profile(capypdf.DeviceColorspace.CMYK, icc_dir / 'FOGRA29L.icc')
-        with capypdf.Generator(ofilename, opt) as gen:
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops = capypdf.DocumentProperties()
+        dprops.set_default_page_properties(pprops)
+        dprops.set_colorspace(capypdf.DeviceColorspace.CMYK)
+        dprops.set_device_profile(capypdf.DeviceColorspace.CMYK, icc_dir / 'FOGRA29L.icc')
+        with capypdf.Generator(ofilename, dprops) as gen:
             c1 = capypdf.Color()
             c1.set_cmyk(0.9, 0, 0.9, 0)
             c2 = capypdf.Color()
@@ -884,11 +884,11 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_imagemask', 200, 200)
     def test_imagemask(self, ofilename, w, h):
-        prop = capypdf.PageProperties()
-        prop.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opt = capypdf.DocumentMetadata()
-        opt.set_default_page_properties(prop)
-        with capypdf.Generator(ofilename, opt) as gen:
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops = capypdf.DocumentProperties()
+        dprops.set_default_page_properties(pprops)
+        with capypdf.Generator(ofilename, dprops) as gen:
             artfile = image_dir / 'comic-lines.png'
             self.assertTrue(artfile.exists())
             maskopt = capypdf.ImagePdfProperties()
@@ -924,11 +924,11 @@ class TestPDFCreation(unittest.TestCase):
     def test_outline(self, ofilename):
         w = 200
         h = 200
-        prop = capypdf.PageProperties()
-        prop.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opt = capypdf.DocumentMetadata()
-        opt.set_default_page_properties(prop)
-        with capypdf.Generator(ofilename, opt) as gen:
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops = capypdf.DocumentProperties()
+        dprops.set_default_page_properties(pprops)
+        with capypdf.Generator(ofilename, dprops) as gen:
             # Destinations point to a page that does not exist when they
             # are created but does exist when the PDF is generated.
             d = capypdf.Destination()
@@ -982,13 +982,13 @@ class TestPDFCreation(unittest.TestCase):
   {gold_k} mul
 }}
 '''
-        prop = capypdf.PageProperties()
-        prop.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opt = capypdf.DocumentMetadata()
-        opt.set_default_page_properties(prop)
-        opt.set_colorspace(capypdf.DeviceColorspace.CMYK)
-        opt.set_device_profile(capypdf.DeviceColorspace.CMYK, icc_dir / 'FOGRA29L.icc')
-        with capypdf.Generator(ofilename, opt) as gen:
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops = capypdf.DocumentProperties()
+        dprops.set_default_page_properties(pprops)
+        dprops.set_colorspace(capypdf.DeviceColorspace.CMYK)
+        dprops.set_device_profile(capypdf.DeviceColorspace.CMYK, icc_dir / 'FOGRA29L.icc')
+        with capypdf.Generator(ofilename, dprops) as gen:
             red = capypdf.Color()
             gold = capypdf.Color()
             red.set_cmyk(0.2, 1, 0.8, 0)
@@ -1008,12 +1008,12 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_blendmodes', 200, 200)
     def test_blendmodes(self, ofilename, w, h):
-        prop = capypdf.PageProperties()
-        prop.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opt = capypdf.DocumentMetadata()
-        opt.set_default_page_properties(prop)
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops = capypdf.DocumentProperties()
+        dprops.set_default_page_properties(pprops)
         params = capypdf.ImagePdfProperties()
-        with capypdf.Generator(ofilename, opt) as gen:
+        with capypdf.Generator(ofilename, dprops) as gen:
             bgimage_ri = gen.load_image(image_dir / 'flame_gradient.png')
             bgimage = gen.add_image(bgimage_ri, params)
             fgimage_ri = gen.load_image(image_dir / 'object_gradient.png')
@@ -1036,11 +1036,11 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_colorpattern', 200, 200)
     def test_colorpattern(self, ofilename, w, h):
-        prop = capypdf.PageProperties()
-        prop.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opt = capypdf.DocumentMetadata()
-        opt.set_default_page_properties(prop)
-        with capypdf.Generator(ofilename, opt) as gen:
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops = capypdf.DocumentProperties()
+        dprops.set_default_page_properties(pprops)
+        with capypdf.Generator(ofilename, dprops) as gen:
             font = gen.load_font(noto_fontdir / 'NotoSerif-Regular.ttf')
             # Repeating pattern.
             pctx = gen.create_tiling_pattern_context(0, 0, 10, 10)
@@ -1075,11 +1075,11 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_annotate', 400, 100)
     def test_annotate(self, ofilename, w, h):
-        prop = capypdf.PageProperties()
-        prop.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opt = capypdf.DocumentMetadata()
-        opt.set_default_page_properties(prop)
-        with capypdf.Generator(ofilename, opt) as gen:
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops = capypdf.DocumentProperties()
+        dprops.set_default_page_properties(pprops)
+        with capypdf.Generator(ofilename, dprops) as gen:
             ta = capypdf.Annotation.new_text_annotation('This is a text ännotation.')
             ta.set_rectangle(30, 80, 40, 90)
             taid = gen.create_annotation(ta)
@@ -1096,12 +1096,12 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_tagged', 200, 200)
     def test_tagged(self, ofilename, w, h):
-        prop = capypdf.PageProperties()
-        prop.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opt = capypdf.DocumentMetadata()
-        opt.set_default_page_properties(prop)
-        opt.set_tagged(True)
-        with capypdf.Generator(ofilename, opt) as gen:
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops = capypdf.DocumentProperties()
+        dprops.set_default_page_properties(pprops)
+        dprops.set_tagged(True)
+        with capypdf.Generator(ofilename, dprops) as gen:
             fid = gen.load_font(noto_fontdir / 'NotoSerif-Regular.ttf')
             bfid = gen.load_font(noto_fontdir / 'NotoSans-Bold.ttf')
             title = 'H1 element'
@@ -1137,12 +1137,12 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_customroles', 200, 200)
     def test_customroles(self, ofilename, w, h):
-        prop = capypdf.PageProperties()
-        prop.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opt = capypdf.DocumentMetadata()
-        opt.set_default_page_properties(prop)
-        opt.set_tagged(True)
-        with capypdf.Generator(ofilename, opt) as gen:
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops = capypdf.DocumentProperties()
+        dprops.set_default_page_properties(pprops)
+        dprops.set_tagged(True)
+        with capypdf.Generator(ofilename, dprops) as gen:
             fid = gen.load_font(noto_fontdir / 'NotoSerif-Regular.ttf')
             bfid = gen.load_font(noto_fontdir / 'NotoSans-Bold.ttf')
             title = 'Headline text'
@@ -1173,12 +1173,12 @@ class TestPDFCreation(unittest.TestCase):
     def test_printersmark(self, ofilename, w, h):
         cropmark_size = 5
         bleed_size = 2*cropmark_size
-        prop = capypdf.PageProperties()
-        prop.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        prop.set_pagebox(capypdf.PageBox.Trim, bleed_size, bleed_size, w - 2*bleed_size, h - 2*bleed_size)
-        opt = capypdf.DocumentMetadata()
-        opt.set_default_page_properties(prop)
-        with capypdf.Generator(ofilename, opt) as gen:
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        pprops.set_pagebox(capypdf.PageBox.Trim, bleed_size, bleed_size, w - 2*bleed_size, h - 2*bleed_size)
+        dprops = capypdf.DocumentProperties()
+        dprops.set_default_page_properties(pprops)
+        with capypdf.Generator(ofilename, dprops) as gen:
             vctx = capypdf.FormXObjectDrawContext(gen, 0, 0, 1, cropmark_size)
             vctx.cmd_re(0, 0, 1, cropmark_size)
             vctx.cmd_f()
@@ -1222,15 +1222,15 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_transparency_groups', 200, 200)
     def test_transparency_groups(self, ofilename, w, h):
-        page_props = capypdf.PageProperties()
+        pprops = capypdf.PageProperties()
         tr_props = capypdf.TransparencyGroupProperties()
         tr_props.set_CS(capypdf.DeviceColorspace.RGB)
-        page_props.set_transparency_group_properties(tr_props)
-        page_props.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opt = capypdf.DocumentMetadata()
-        opt.set_default_page_properties(page_props)
+        pprops.set_transparency_group_properties(tr_props)
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops = capypdf.DocumentProperties()
+        dprops.set_default_page_properties(pprops)
 
-        with capypdf.Generator(ofilename, opt) as gen:
+        with capypdf.Generator(ofilename, dprops) as gen:
             # Test transparency painting within transparency group
             gstate = capypdf.GraphicsState()
             gstate.set_CA(0.5)
@@ -1264,17 +1264,17 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_pdfx3', 200, 200)
     def test_pdfx3(self, ofilename, w, h):
-        prop = capypdf.PageProperties()
-        prop.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        prop.set_pagebox(capypdf.PageBox.Trim, 1, 1, 198, 198)
-        opt = capypdf.DocumentMetadata()
-        opt.set_default_page_properties(prop)
-        opt.set_colorspace(capypdf.DeviceColorspace.CMYK)
-        opt.set_output_intent('Uncoated Fogra 29')
-        opt.set_pdfx(capypdf.PdfXType.X3_2003)
-        opt.set_device_profile(capypdf.DeviceColorspace.CMYK, icc_dir / 'FOGRA29L.icc')
-        opt.set_title('PDF X3 test')
-        with capypdf.Generator(ofilename, opt) as gen:
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        pprops.set_pagebox(capypdf.PageBox.Trim, 1, 1, 198, 198)
+        dprops = capypdf.DocumentProperties()
+        dprops.set_default_page_properties(pprops)
+        dprops.set_colorspace(capypdf.DeviceColorspace.CMYK)
+        dprops.set_output_intent('Uncoated Fogra 29')
+        dprops.set_pdfx(capypdf.PdfXType.X3_2003)
+        dprops.set_device_profile(capypdf.DeviceColorspace.CMYK, icc_dir / 'FOGRA29L.icc')
+        dprops.set_title('PDF X3 test')
+        with capypdf.Generator(ofilename, dprops) as gen:
             fid = gen.load_font(noto_fontdir / 'NotoSerif-Regular.ttf')
             with gen.page_draw_context() as ctx:
                 ctx.render_text('This document should validate as PDF/X3.', fid, 8, 10, 180)
@@ -1296,12 +1296,12 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_shading_transparency', 200, 200)
     def test_shading_transparency(self, ofilename, w, h):
-        prop = capypdf.PageProperties()
-        prop.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opt = capypdf.DocumentMetadata()
-        opt.set_default_page_properties(prop)
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops = capypdf.DocumentProperties()
+        dprops.set_default_page_properties(pprops)
 
-        with capypdf.Generator(ofilename, opt) as gen:
+        with capypdf.Generator(ofilename, dprops) as gen:
             # Fill gradient + opacity gradient
             c1 = capypdf.Color()
             o1 = capypdf.Color()
@@ -1365,12 +1365,12 @@ class TestPDFCreation(unittest.TestCase):
 
     @validate_image('python_shading_pattern', 200, 200)
     def test_shading_pattern(self, ofilename, w, h):
-        prop = capypdf.PageProperties()
-        prop.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
-        opt = capypdf.DocumentMetadata()
-        opt.set_default_page_properties(prop)
+        pprops = capypdf.PageProperties()
+        pprops.set_pagebox(capypdf.PageBox.Media, 0, 0, w, h)
+        dprops = capypdf.DocumentProperties()
+        dprops.set_default_page_properties(pprops)
 
-        with capypdf.Generator(ofilename, opt) as gen:
+        with capypdf.Generator(ofilename, dprops) as gen:
             # Fill gradient
             c1 = capypdf.Color()
             c2 = capypdf.Color()

--- a/test/cpptest.cpp
+++ b/test/cpptest.cpp
@@ -17,8 +17,8 @@ int main() {
         return 1;
     }
 
-    capypdf::DocumentMetadata md;
-    capypdf::Generator gen(fname, md);
+    capypdf::DocumentProperties docpropd;
+    capypdf::Generator gen(fname, docpropd);
     capypdf::DrawContext dc = gen.new_page_context();
     dc.cmd_rg(1.0, 0.1, 0.5);
     dc.cmd_re(100, 100, 200, 200);

--- a/test/ctest.c
+++ b/test/ctest.c
@@ -10,7 +10,7 @@
 int main() {
     CapyPDF_EC rc;
     CapyPDF_Generator *gen;
-    CapyPDF_DocumentMetadata *opt;
+    CapyPDF_DocumentProperties *opt;
     CapyPDF_DrawContext *dc;
     const char *fname = "capy_ctest.pdf";
     FILE *f;
@@ -21,7 +21,7 @@ int main() {
         return 1;
     }
 
-    if((rc = capy_doc_md_new(&opt)) != 0) {
+    if((rc = capy_document_properties_new(&opt)) != 0) {
         fprintf(stderr, "%s\n", capy_error_message(rc));
         return 1;
     }
@@ -31,7 +31,7 @@ int main() {
         return 1;
     }
 
-    if((rc = capy_doc_md_destroy(opt)) != 0) {
+    if((rc = capy_document_properties_destroy(opt)) != 0) {
         fprintf(stderr, "%s\n", capy_error_message(rc));
         return 1;
     }


### PR DESCRIPTION
It turned out that PDF has its own entities that are called metadata. Rename our metdata class to avoid confusion and name clashes.

Heads up to @doctormo.