### PR TITLE
Add image properties to C++ API

### DIFF
--- a/src/drawcontext.cpp
+++ b/src/drawcontext.cpp
@@ -94,8 +94,8 @@ DCSerialization PdfDrawContext::serialize() {
         if(group_matrix) {
             write_matrix(app, group_matrix.value());
         }
-        std::format_to(app, "/XStep {:f}", get_w());
-        std::format_to(app, "/YStep {:f}", get_h());
+        std::format_to(app, "  /XStep {:f}\n", get_w());
+        std::format_to(app, "  /YStep {:f}\n", get_h());
         std::format_to(app,
                        R"(  /Resources {}
   /Length {}


### PR DESCRIPTION
~This adds the a bunch of cpp API for raster images but also allows us to define the type explicityly.~

This is needed because for now, I'm writing the rasters out to temporary files, and the temp files never have extensions so there's no way to detect them.

The output for this isn't great though. The RGB JPEG works ok, the RGB PNGs work ok but the Tiff refused to load at all (unsupported std::exception) and the CMYK jpeg loads in a broken way: [output.pdf](https://github.com/user-attachments/files/18014319/output.pdf)
src: [11-rasters](https://github.com/user-attachments/assets/5d57685d-243b-4eef-bcf3-a7c67a22906f)

