### PR TITLE
Add text commands to cpp interface

### DIFF
--- a/include/capypdf.h.in
+++ b/include/capypdf.h.in
@@ -771,6 +771,7 @@ CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_BDC_builtin(CapyPDF_Text *text,
 CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_EMC(CapyPDF_Text *text) CAPYPDF_NOEXCEPT;
 CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_Tc(CapyPDF_Text *text, double spacing) CAPYPDF_NOEXCEPT;
 CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_Td(CapyPDF_Text *text, double x, double y) CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_TD(CapyPDF_Text *text, double x, double y) CAPYPDF_NOEXCEPT;
 CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_Tf(CapyPDF_Text *text,
                                            CapyPDF_FontId font,
                                            double pointsize) CAPYPDF_NOEXCEPT;

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1107,6 +1107,13 @@ CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_Td(CapyPDF_Text *text,
     return conv_err(t->cmd_Td(x, y));
 }
 
+CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_TD(CapyPDF_Text *text,
+                                           double x,
+                                           double y) CAPYPDF_NOEXCEPT {
+    auto *t = reinterpret_cast<PdfText *>(text);
+    return conv_err(t->cmd_TD(x, y));
+}
+
 CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_Tf(CapyPDF_Text *text,
                                            CapyPDF_FontId font,
                                            double pointsize) CAPYPDF_NOEXCEPT {


### PR DESCRIPTION
Added the text interfaces to the C++ API

Omitted are the stroke and fill setters, since these are handled by the draw context.

Added the missing `cmd_TD` to the capi since it was there in the code, but not expressed.

I had a go at adding the Quote and Double Quote commands, but the text code is hard to understand. The goal for quote is to say "new line" and double quote is "new line with this Tw and Tc spacing" which can be quite useful for translating SVG 2.0 flowed text if you have to time to add them.