### PR TITLE
Store binary data in type appropriate container

### DIFF
--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -2100,8 +2100,8 @@ CAPYPDF_PUBLIC CapyPDF_EC capy_soft_mask_destroy(CapyPDF_SoftMask *sm) CAPYPDF_N
 CAPYPDF_PUBLIC CapyPDF_EC capy_embedded_file_new(const char *path,
                                                  CapyPDF_EmbeddedFile **out_ptr) CAPYPDF_NOEXCEPT {
     std::filesystem::path fspath(path);
-    auto pathless_name = fspath.filename();
-    auto rc = u8string::from_cstr(pathless_name.string().c_str());
+    auto pathless_name = fspath.filename().string();
+    auto rc = validate_utf8(pathless_name.c_str(), pathless_name.size());
     if(!rc) {
         return conv_err(rc);
     }

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1496,7 +1496,8 @@ CAPYPDF_PUBLIC CapyPDF_EC capy_raster_image_builder_set_size(CapyPDF_RasterImage
 CAPYPDF_PUBLIC CapyPDF_EC capy_raster_image_builder_set_pixel_data(
     CapyPDF_RasterImageBuilder *builder, const char *buf, uint64_t bufsize) CAPYPDF_NOEXCEPT {
     auto *b = reinterpret_cast<RasterImageBuilder *>(builder);
-    b->i.pixels.assign(buf, buf + bufsize);
+    auto *byteptr = (std::byte *)buf;
+    b->i.pixels.assign(byteptr, byteptr + bufsize);
     RETNOERR;
 }
 

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -506,7 +506,8 @@ CAPYPDF_PUBLIC CapyPDF_EC capy_generator_add_icc_profile(CapyPDF_Generator *gen,
                                                          CapyPDF_IccColorSpaceId *out_ptr)
     CAPYPDF_NOEXCEPT {
     auto *g = reinterpret_cast<PdfGen *>(gen);
-    auto rc = g->add_icc_profile({buf, bufsize}, num_channels);
+    std::byte *bytebuf = (std::byte *)buf;
+    auto rc = g->add_icc_profile({bytebuf, bufsize}, num_channels);
     if(rc) {
         *out_ptr = rc.value();
     }

--- a/src/colorconverter.cpp
+++ b/src/colorconverter.cpp
@@ -275,7 +275,8 @@ rvoe<RawPixelImage> PdfColorConverter::convert_image_to(RawPixelImage ri,
     if(!transform) {
         RETERR(ProfileProblem);
     }
-    converted.pixels = std::string(num_pixels * num_bytes_for(output_format), '\0');
+    converted.pixels =
+        std::vector<std::byte>(num_pixels * num_bytes_for(output_format), std::byte{0});
     cmsDoTransform(transform, ri.pixels.data(), converted.pixels.data(), num_pixels);
     cmsDeleteTransform(transform);
     converted.md.cs = (CapyPDF_Image_Colorspace)output_format;

--- a/src/colorconverter.cpp
+++ b/src/colorconverter.cpp
@@ -89,7 +89,7 @@ PdfColorConverter::construct(const std::filesystem::path &rgb_profile_fname,
                              const std::filesystem::path &cmyk_profile_fname) {
     PdfColorConverter conv;
     if(!rgb_profile_fname.empty()) {
-        ERC(rgb, load_file_as_string(rgb_profile_fname));
+        ERC(rgb, load_file_as_bytes(rgb_profile_fname));
         conv.rgb_profile_data = std::move(rgb);
         cmsHPROFILE h =
             cmsOpenProfileFromMem(conv.rgb_profile_data.data(), conv.rgb_profile_data.size());
@@ -105,7 +105,7 @@ PdfColorConverter::construct(const std::filesystem::path &rgb_profile_fname,
         conv.rgb_profile.h = cmsCreate_sRGBProfile();
     }
     if(!gray_profile_fname.empty()) {
-        ERC(gray, load_file_as_string(gray_profile_fname));
+        ERC(gray, load_file_as_bytes(gray_profile_fname));
         conv.gray_profile_data = std::move(gray);
         auto h =
             cmsOpenProfileFromMem(conv.gray_profile_data.data(), conv.gray_profile_data.size());
@@ -123,7 +123,7 @@ PdfColorConverter::construct(const std::filesystem::path &rgb_profile_fname,
         cmsFreeToneCurve(curve);
     }
     if(!cmyk_profile_fname.empty()) {
-        ERC(cmyk, load_file_as_string(cmyk_profile_fname));
+        ERC(cmyk, load_file_as_bytes(cmyk_profile_fname));
         conv.cmyk_profile_data = std::move(cmyk);
         auto h =
             cmsOpenProfileFromMem(conv.cmyk_profile_data.data(), conv.cmyk_profile_data.size());
@@ -284,9 +284,15 @@ rvoe<RawPixelImage> PdfColorConverter::convert_image_to(RawPixelImage ri,
     return converted;
 }
 
-std::span<std::byte> PdfColorConverter::get_rgb() const { return str2span(rgb_profile_data); }
-std::span<std::byte> PdfColorConverter::get_gray() const { return str2span(gray_profile_data); }
-std::span<std::byte> PdfColorConverter::get_cmyk() const { return str2span(cmyk_profile_data); }
+std::span<std::byte> PdfColorConverter::get_rgb() {
+    return std::span<std::byte>(rgb_profile_data.data(), rgb_profile_data.size());
+}
+std::span<std::byte> PdfColorConverter::get_gray() {
+    return std::span<std::byte>(gray_profile_data.data(), gray_profile_data.size());
+}
+std::span<std::byte> PdfColorConverter::get_cmyk() {
+    return std::span<std::byte>(cmyk_profile_data.data(), cmyk_profile_data.size());
+}
 
 rvoe<int> PdfColorConverter::get_num_channels(std::span<std::byte> icc_data) const {
     cmsHPROFILE h = cmsOpenProfileFromMem(icc_data.data(), icc_data.size());

--- a/src/colorconverter.hpp
+++ b/src/colorconverter.hpp
@@ -54,9 +54,9 @@ public:
                                          CapyPDF_Device_Colorspace output_format,
                                          CapyPDF_Rendering_Intent intent) const;
 
-    std::span<std::byte> get_rgb() const;
-    std::span<std::byte> get_gray() const;
-    std::span<std::byte> get_cmyk() const;
+    std::span<std::byte> get_rgb();
+    std::span<std::byte> get_gray();
+    std::span<std::byte> get_cmyk();
 
     rvoe<int> get_num_channels(std::span<std::byte> icc_data) const;
 
@@ -72,7 +72,7 @@ private:
     LcmsHolder gray_profile;
     LcmsHolder cmyk_profile;
 
-    std::string rgb_profile_data, gray_profile_data, cmyk_profile_data;
+    std::vector<std::byte> rgb_profile_data, gray_profile_data, cmyk_profile_data;
     // FIXME, store transforms so that they don't get recreated all the time.
 };
 

--- a/src/colorconverter.hpp
+++ b/src/colorconverter.hpp
@@ -54,11 +54,11 @@ public:
                                          CapyPDF_Device_Colorspace output_format,
                                          CapyPDF_Rendering_Intent intent) const;
 
-    const std::string &get_rgb() const { return rgb_profile_data; }
-    const std::string &get_gray() const { return gray_profile_data; }
-    const std::string &get_cmyk() const { return cmyk_profile_data; }
+    std::span<std::byte> get_rgb() const;
+    std::span<std::byte> get_gray() const;
+    std::span<std::byte> get_cmyk() const;
 
-    rvoe<int> get_num_channels(std::string_view icc_data) const;
+    rvoe<int> get_num_channels(std::span<std::byte> icc_data) const;
 
     PdfColorConverter &operator=(PdfColorConverter &&o) = default;
 

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -1138,11 +1138,11 @@ rvoe<CapyPDF_ImageId> PdfDocument::add_image_object(uint32_t w,
                                                     ImageColorspaceType colorspace,
                                                     std::optional<int32_t> smask_id,
                                                     const ImagePDFProperties &params,
-                                                    std::string_view original_bytes,
+                                                    std::span<std::byte> original_bytes,
                                                     CapyPDF_Compression compression) {
     std::string buf;
-    std::string compression_buffer;
-    std::string_view compressed_bytes;
+    std::vector<std::byte> compression_buffer;
+    std::span<std::byte> compressed_bytes;
     switch(compression) {
     case CAPY_COMPRESSION_NONE: {
         ERC(trial_compressed, flate_compress(original_bytes));

--- a/src/document.hpp
+++ b/src/document.hpp
@@ -119,7 +119,7 @@ struct FullPDFObject {
 
 struct DeflatePDFObject {
     std::string unclosed_dictionary;
-    std::string stream;
+    RawData stream;
 };
 
 struct DelayedSubsetFontData {

--- a/src/document.hpp
+++ b/src/document.hpp
@@ -503,7 +503,7 @@ private:
                                            ImageColorspaceType colorspace,
                                            std::optional<int32_t> smask_id,
                                            const ImagePDFProperties &params,
-                                           std::string_view original_bytes,
+                                           std::span<std::byte> original_bytes,
                                            CapyPDF_Compression compression);
 
     rvoe<NoReturnValue> generate_info_object();

--- a/src/document.hpp
+++ b/src/document.hpp
@@ -114,7 +114,7 @@ struct DummyIndexZero {};
 
 struct FullPDFObject {
     std::string dictionary;
-    std::string stream;
+    RawData stream;
 };
 
 struct DeflatePDFObject {
@@ -390,7 +390,8 @@ public:
                                                  CapyPDF_FunctionId fid);
     rvoe<CapyPDF_LabColorSpaceId> add_lab_colorspace(const LabColorSpace &lab);
     rvoe<CapyPDF_IccColorSpaceId> load_icc_file(const std::filesystem::path &fname);
-    rvoe<CapyPDF_IccColorSpaceId> add_icc_profile(std::string_view contents, int32_t num_channels);
+    rvoe<CapyPDF_IccColorSpaceId> add_icc_profile(std::span<std::byte> contents,
+                                                  int32_t num_channels);
 
     // Fonts
     rvoe<CapyPDF_FontId> load_font(FT_Library ft, const std::filesystem::path &fname);
@@ -487,7 +488,7 @@ private:
         return ocg_items.at(ocgid.id);
     }
 
-    std::optional<CapyPDF_IccColorSpaceId> find_icc_profile(std::string_view contents);
+    std::optional<CapyPDF_IccColorSpaceId> find_icc_profile(std::span<std::byte> contents);
 
     rvoe<NoReturnValue> create_catalog();
 

--- a/src/ft_subsetter.cpp
+++ b/src/ft_subsetter.cpp
@@ -909,7 +909,7 @@ rvoe<std::string> generate_font(const TrueTypeFontFile &source,
 }
 
 rvoe<TrueTypeFontFile> load_and_parse_truetype_font(const std::filesystem::path &fname) {
-    ERC(buf, load_file(fname));
+    ERC(buf, load_file_as_string(fname));
     return parse_truetype_font(std::string_view{buf.data(), buf.size()});
 }
 

--- a/src/generator.hpp
+++ b/src/generator.hpp
@@ -82,7 +82,7 @@ public:
     rvoe<CapyPDF_IccColorSpaceId> load_icc_file(const std::filesystem::path &fname) {
         return pdoc.load_icc_file(fname);
     }
-    rvoe<CapyPDF_IccColorSpaceId> add_icc_profile(const std::string_view &bytes,
+    rvoe<CapyPDF_IccColorSpaceId> add_icc_profile(std::span<std::byte> bytes,
                                                   uint32_t num_channels) {
         return pdoc.add_icc_profile(bytes, num_channels);
     }

--- a/src/pdfcommon.cpp
+++ b/src/pdfcommon.cpp
@@ -160,4 +160,31 @@ CodepointIterator::CharInfo CodepointIterator::extract_one_codepoint(const unsig
     return CharInfo{unpack_one(buf, par), 1 + par.num_subsequent_bytes};
 }
 
+const char *RawData::data() const {
+    if(auto *d = std::get_if<std::string>(&storage)) {
+        return d->data();
+    } else if(auto *d = std::get_if<std::vector<std::byte>>(&storage)) {
+        return (const char *)d->data();
+    } else {
+        std::abort();
+    }
+}
+
+size_t RawData::size() const {
+    if(auto *d = std::get_if<std::string>(&storage)) {
+        return d->size();
+    } else if(auto *d = std::get_if<std::vector<std::byte>>(&storage)) {
+        return d->size();
+    } else {
+        std::abort();
+    }
+}
+
+std::string_view RawData::sv() const { return std::string_view{data(), size()}; }
+
+std::span<std::byte> RawData::span() const {
+    auto *byteptr = (std::byte *)(data());
+    return std::span<std::byte>{byteptr, size()};
+}
+
 } // namespace capypdf::internal

--- a/src/pdfcommon.hpp
+++ b/src/pdfcommon.hpp
@@ -14,6 +14,7 @@
 #include <functional>
 #include <variant>
 #include <iterator>
+#include <span>
 
 #include <cstdint>
 #include <cmath>
@@ -242,6 +243,21 @@ private:
     }
 
     double value;
+};
+
+class RawData {
+private:
+    std::variant<std::string, std::vector<std::byte>> storage;
+
+public:
+    explicit RawData(std::string input) : storage{std::move(input)} {};
+    explicit RawData(std::vector<std::byte> input) : storage(std::move(input)) {}
+
+    const char *data() const;
+    size_t size() const;
+
+    std::string_view sv() const;
+    std::span<std::byte> span() const;
 };
 
 // Every resource type has its own id type to avoid

--- a/src/pdfcommon.hpp
+++ b/src/pdfcommon.hpp
@@ -250,14 +250,29 @@ private:
     std::variant<std::string, std::vector<std::byte>> storage;
 
 public:
-    explicit RawData(std::string input) : storage{std::move(input)} {};
-    explicit RawData(std::vector<std::byte> input) : storage(std::move(input)) {}
+    RawData() : storage{} {}
+    explicit RawData(std::string input);
+    explicit RawData(std::vector<std::byte> input);
+    explicit RawData(std::string_view input);
+    explicit RawData(std::span<std::byte> input);
 
     const char *data() const;
     size_t size() const;
 
     std::string_view sv() const;
     std::span<std::byte> span() const;
+
+    bool empty() const;
+    void clear();
+
+    void assign(const char *buf, size_t bufsize);
+    void assign(const std::byte *buf, size_t bufsize);
+
+    RawData &operator=(std::string input);
+    RawData &operator=(std::vector<std::byte> input);
+
+    bool operator==(std::string_view other) const;
+    bool operator==(std::span<std::byte> other) const;
 };
 
 // Every resource type has its own id type to avoid
@@ -545,7 +560,7 @@ struct RawPixelImage {
     RasterImageMetadata md;
     std::string pixels;
     std::string alpha;
-    std::string icc_profile;
+    std::vector<std::byte> icc_profile;
 };
 
 struct jpg_image {
@@ -554,8 +569,8 @@ struct jpg_image {
     uint32_t depth;
     CapyPDF_Device_Colorspace cs;
     bool invert_channels = false;
-    std::string file_contents;
-    std::string icc_profile;
+    std::vector<std::byte> file_contents;
+    std::vector<std::byte> icc_profile;
 };
 
 typedef std::variant<RawPixelImage, jpg_image> RasterImage;

--- a/src/pdfcommon.hpp
+++ b/src/pdfcommon.hpp
@@ -558,8 +558,8 @@ struct RasterImageMetadata {
 
 struct RawPixelImage {
     RasterImageMetadata md;
-    std::string pixels;
-    std::string alpha;
+    std::vector<std::byte> pixels;
+    std::vector<std::byte> alpha;
     std::vector<std::byte> icc_profile;
 };
 

--- a/src/pdfwriter.cpp
+++ b/src/pdfwriter.cpp
@@ -233,7 +233,7 @@ rvoe<std::vector<uint64_t>> PdfWriter::write_objects() {
         },
 
         [&](const DeflatePDFObject &pobj) -> rvoe<NoReturnValue> {
-            ERC(compressed, flate_compress(pobj.stream));
+            ERC(compressed, flate_compress(pobj.stream.sv()));
             std::string dict = std::format("{}  /Filter /FlateDecode\n  /Length {}\n>>\n",
                                            pobj.unclosed_dictionary,
                                            compressed.size());

--- a/src/pdfwriter.cpp
+++ b/src/pdfwriter.cpp
@@ -228,7 +228,7 @@ rvoe<std::vector<uint64_t>> PdfWriter::write_objects() {
         [](DummyIndexZero &) -> rvoe<NoReturnValue> { RETOK; },
 
         [&](const FullPDFObject &pobj) -> rvoe<NoReturnValue> {
-            ERCV(write_finished_object(i, pobj.dictionary, pobj.stream));
+            ERCV(write_finished_object(i, pobj.dictionary, pobj.stream.sv()));
             RETOK;
         },
 

--- a/src/pdfwriter.hpp
+++ b/src/pdfwriter.hpp
@@ -29,7 +29,7 @@ private:
     rvoe<NoReturnValue> write_trailer(int64_t xref_offset);
     rvoe<NoReturnValue> write_finished_object(int32_t object_number,
                                               std::string_view dict_data,
-                                              std::string_view stream_data);
+                                              std::span<std::byte> stream_data);
     rvoe<NoReturnValue> write_subset_font_data(int32_t object_num,
                                                const DelayedSubsetFontData &ssfont);
     void write_subset_font_descriptor(int32_t object_num,

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -22,7 +22,8 @@ template<class... Ts> struct overloaded : Ts... {
 template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
 #endif
 
-rvoe<std::string> flate_compress(std::string_view data);
+rvoe<std::vector<std::byte>> flate_compress(std::string_view data);
+rvoe<std::vector<std::byte>> flate_compress(std::span<std::byte> data);
 
 rvoe<std::string> load_file_as_string(const char *fname);
 
@@ -59,5 +60,6 @@ void serialize_trans(std::back_insert_iterator<std::string> buf_append,
 void quote_xml_element_data_into(const u8string &content, std::string &result);
 
 std::span<std::byte> str2span(const std::string &s);
+std::string_view span2sv(std::span<std::byte> s);
 
 } // namespace capypdf::internal

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -24,11 +24,15 @@ template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
 
 rvoe<std::string> flate_compress(std::string_view data);
 
-rvoe<std::string> load_file(const char *fname);
+rvoe<std::string> load_file_as_string(const char *fname);
 
-rvoe<std::string> load_file(const std::filesystem::path &fname);
+rvoe<std::string> load_file_as_string(const std::filesystem::path &fname);
 
-rvoe<std::string> load_file(FILE *f);
+rvoe<std::string> load_file_as_string(FILE *f);
+
+rvoe<std::vector<std::byte>> load_file_as_bytes(const std::filesystem::path &fname);
+
+rvoe<std::vector<std::byte>> load_file_as_bytes(FILE *f);
 
 void write_file(const char *ofname, const char *buf, size_t bufsize);
 
@@ -53,5 +57,7 @@ void serialize_trans(std::back_insert_iterator<std::string> buf_append,
                      std::string_view indent);
 
 void quote_xml_element_data_into(const u8string &content, std::string &result);
+
+std::span<std::byte> str2span(const std::string &s);
 
 } // namespace capypdf::internal


### PR DESCRIPTION
Storing raw byte data in `std::string`s was a simple way to get things started. It works nicely but can be a bit confusing. So do what Python does and have separate types for "bytes that are strings" and "bytes that are a binary blob".