### PR TITLE
Add drawing commands into Text BT blocks

### DIFF
--- a/include/capypdf.h.in
+++ b/include/capypdf.h.in
@@ -815,6 +815,19 @@ CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_Tw(CapyPDF_Text *text, double spacing) C
 CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_Tstar(CapyPDF_Text *text) CAPYPDF_NOEXCEPT;
 CAPYPDF_PUBLIC CapyPDF_EC capy_text_destroy(CapyPDF_Text *text) CAPYPDF_NOEXCEPT;
 
+CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_w(CapyPDF_Text *text, double line_width) CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_M(CapyPDF_Text *text, double miterlimit) CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_j(CapyPDF_Text *text,
+                                          CapyPDF_Line_Join join_style) CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_J(CapyPDF_Text *text,
+                                          CapyPDF_Line_Cap cap_style) CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_d(CapyPDF_Text *text,
+                                          double *dash_array,
+                                          int32_t array_size,
+                                          double phase) CAPYPDF_NOEXCEPT;
+CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_gs(CapyPDF_Text *text,
+                                           CapyPDF_GraphicsStateId gsid) CAPYPDF_NOEXCEPT;
+
 // Color
 
 CAPYPDF_PUBLIC CapyPDF_EC capy_color_new(CapyPDF_Color **out_ptr) CAPYPDF_NOEXCEPT;

--- a/include/capypdf.hpp
+++ b/include/capypdf.hpp
@@ -245,6 +245,35 @@ public:
     }
 };
 
+class Color : public CapyC<CapyPDF_Color> {
+public:
+    friend class DrawContext;
+    friend class Text;
+    friend class Type2Function;
+    friend class Type4Shading;
+    friend class Type6Shading;
+
+    Color() {
+        CapyPDF_Color *c;
+        CAPY_CPP_CHECK(capy_color_new(&c));
+        _d.reset(c);
+    }
+
+    void set_rgb(double r, double g, double b) {
+        CAPY_CPP_CHECK(capy_color_set_rgb(*this, r, g, b));
+    }
+    void set_cmyk(double c, double m, double y, double k) {
+        CAPY_CPP_CHECK(capy_color_set_cmyk(*this, c, m, y, k));
+    }
+    void set_gray(double g) { CAPY_CPP_CHECK(capy_color_set_gray(*this, g)); }
+    void set_icc(CapyPDF_IccColorSpaceId icc_id, double *values, int32_t num_values) {
+        CAPY_CPP_CHECK(capy_color_set_icc(*this, icc_id, values, num_values));
+    }
+    void set_pattern(CapyPDF_PatternId pattern_id) {
+        CAPY_CPP_CHECK(capy_color_set_pattern(*this, pattern_id));
+    }
+};
+
 class TextSequence : public CapyC<CapyPDF_TextSequence> {
     friend class Text;
 
@@ -324,36 +353,19 @@ public:
 
     void cmd_EMC() { CAPY_CPP_CHECK(capy_text_cmd_EMC(*this)); }
 
+    void set_nonstroke(Color &color) { CAPY_CPP_CHECK(capy_text_set_nonstroke(*this, color)); }
+    void set_stroke(Color &color) { CAPY_CPP_CHECK(capy_text_set_stroke(*this, color)); }
+    void cmd_w(double value) { CAPY_CPP_CHECK(capy_text_cmd_w(*this, value)); }
+    void cmd_M(double value) { CAPY_CPP_CHECK(capy_text_cmd_M(*this, value)); }
+    void cmd_j(CapyPDF_Line_Join value) { CAPY_CPP_CHECK(capy_text_cmd_j(*this, value)); }
+    void cmd_J(CapyPDF_Line_Cap value) { CAPY_CPP_CHECK(capy_text_cmd_J(*this, value)); }
+    void cmd_d(double *values, int32_t num_values, double offset) {
+        CAPY_CPP_CHECK(capy_text_cmd_d(*this, values, num_values, offset));
+    }
+    void cmd_gs(CapyPDF_GraphicsStateId gsid) { CAPY_CPP_CHECK(capy_text_cmd_gs(*this, gsid)); }
+
 private:
     explicit Text(CapyPDF_Text *text) { _d.reset(text); }
-};
-
-class Color : public CapyC<CapyPDF_Color> {
-public:
-    friend class DrawContext;
-    friend class Type2Function;
-    friend class Type4Shading;
-    friend class Type6Shading;
-
-    Color() {
-        CapyPDF_Color *c;
-        CAPY_CPP_CHECK(capy_color_new(&c));
-        _d.reset(c);
-    }
-
-    void set_rgb(double r, double g, double b) {
-        CAPY_CPP_CHECK(capy_color_set_rgb(*this, r, g, b));
-    }
-    void set_cmyk(double c, double m, double y, double k) {
-        CAPY_CPP_CHECK(capy_color_set_cmyk(*this, c, m, y, k));
-    }
-    void set_gray(double g) { CAPY_CPP_CHECK(capy_color_set_gray(*this, g)); }
-    void set_icc(CapyPDF_IccColorSpaceId icc_id, double *values, int32_t num_values) {
-        CAPY_CPP_CHECK(capy_color_set_icc(*this, icc_id, values, num_values));
-    }
-    void set_pattern(CapyPDF_PatternId pattern_id) {
-        CAPY_CPP_CHECK(capy_color_set_pattern(*this, pattern_id));
-    }
 };
 
 class GraphicsState : public CapyC<CapyPDF_GraphicsState> {

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1462,6 +1462,49 @@ CAPYPDF_PUBLIC CapyPDF_EC capy_text_set_stroke(CapyPDF_Text *text,
     API_BOUNDARY_END;
 }
 
+CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_w(CapyPDF_Text *text, double line_width) CAPYPDF_NOEXCEPT {
+    API_BOUNDARY_START;
+    auto *t = reinterpret_cast<PdfText *>(text);
+    return conv_err(t->cmd_w(line_width));
+    API_BOUNDARY_END;
+}
+CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_M(CapyPDF_Text *text, double miterlimit) CAPYPDF_NOEXCEPT {
+    API_BOUNDARY_START;
+    auto *t = reinterpret_cast<PdfText *>(text);
+    return conv_err(t->cmd_M(miterlimit));
+    API_BOUNDARY_END;
+}
+CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_j(CapyPDF_Text *text,
+                                          CapyPDF_Line_Join join_style) CAPYPDF_NOEXCEPT {
+    API_BOUNDARY_START;
+    auto *t = reinterpret_cast<PdfText *>(text);
+    return conv_err(t->cmd_j(join_style));
+    API_BOUNDARY_END;
+}
+CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_J(CapyPDF_Text *text,
+                                          CapyPDF_Line_Cap cap_style) CAPYPDF_NOEXCEPT {
+    API_BOUNDARY_START;
+    auto *t = reinterpret_cast<PdfText *>(text);
+    return conv_err(t->cmd_J(cap_style));
+    API_BOUNDARY_END;
+}
+CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_d(CapyPDF_Text *text,
+                                          double *dash_array,
+                                          int32_t array_size,
+                                          double phase) CAPYPDF_NOEXCEPT {
+    API_BOUNDARY_START;
+    auto *t = reinterpret_cast<PdfText *>(text);
+    return conv_err(t->cmd_d(dash_array, array_size, phase));
+    API_BOUNDARY_END;
+}
+CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_gs(CapyPDF_Text *text,
+                                           CapyPDF_GraphicsStateId gsid) CAPYPDF_NOEXCEPT {
+    API_BOUNDARY_START;
+    auto *t = reinterpret_cast<PdfText *>(text);
+    return conv_err(t->cmd_gs(gsid));
+    API_BOUNDARY_END;
+}
+
 CAPYPDF_PUBLIC CapyPDF_EC capy_text_cmd_BDC_builtin(CapyPDF_Text *text,
                                                     CapyPDF_StructureItemId stid) CAPYPDF_NOEXCEPT {
     API_BOUNDARY_START;

--- a/src/pdftext.hpp
+++ b/src/pdftext.hpp
@@ -168,6 +168,31 @@ struct StructureItem {
     CapyPDF_StructureItemId sid;
 };
 
+struct M_arg {
+    double miterlimit;
+};
+
+struct w_arg {
+    double width;
+};
+
+struct j_arg {
+    CapyPDF_Line_Join join_style;
+};
+
+struct J_arg {
+    CapyPDF_Line_Cap cap_style;
+};
+
+struct d_arg {
+    std::vector<double> array;
+    double phase;
+};
+
+struct gs_arg {
+    CapyPDF_GraphicsStateId gid;
+};
+
 typedef std::variant<TStar_arg,
                      Tc_arg,
                      Td_arg,
@@ -184,7 +209,13 @@ typedef std::variant<TStar_arg,
                      StructureItem,
                      Emc_arg,
                      Stroke_arg,
-                     Nonstroke_arg>
+                     Nonstroke_arg,
+                     M_arg,
+                     w_arg,
+                     j_arg,
+                     J_arg,
+                     d_arg,
+                     gs_arg>
     TextEvent;
 
 class PdfText {
@@ -279,6 +310,33 @@ public:
 
     rvoe<NoReturnValue> nonstroke_color(const Color &c) {
         events.emplace_back(Nonstroke_arg{c});
+        RETOK;
+    }
+
+    rvoe<NoReturnValue> cmd_w(double line_width) {
+        events.emplace_back(w_arg{line_width});
+        RETOK;
+    }
+    rvoe<NoReturnValue> cmd_M(double miterlimit) {
+        events.emplace_back(M_arg{miterlimit});
+        RETOK;
+    }
+    rvoe<NoReturnValue> cmd_j(CapyPDF_Line_Join join_style) {
+        events.emplace_back(j_arg{join_style});
+        RETOK;
+    }
+    rvoe<NoReturnValue> cmd_J(CapyPDF_Line_Cap cap_style) {
+        events.emplace_back(J_arg{cap_style});
+        RETOK;
+    }
+    rvoe<NoReturnValue> cmd_d(double *dash_array, int32_t array_size, double phase) {
+        std::vector<double> array;
+        array.assign(dash_array, dash_array + array_size);
+        events.emplace_back(d_arg{std::move(array), phase});
+        RETOK;
+    }
+    rvoe<NoReturnValue> cmd_gs(CapyPDF_GraphicsStateId gsid) {
+        events.emplace_back(gs_arg{gsid});
         RETOK;
     }
 


### PR DESCRIPTION
I really don't like this duplication.

Having looked at how this is organised, I can see some important ways this could and maybe should be refactored.

So far I can have text with patterns and gradients, opacities and such. There's some detail to work out about strokes and it seems like graphics states interact with each other so that might need to be cleared up too.