### PR TITLE
Create PDF 2.0 by default.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 *.user
 *.user.*
 __pycache__
+subprojects/.wraplock
+

--- a/readme.md
+++ b/readme.md
@@ -10,13 +10,16 @@ directly.
 
 ## Features
 
-- Aims to support all functionality available in PDF (eventually)
+- Aims to support all functionality in PDF (eventually), including
+  accessibility features
 - Reads PNG, JPEG and TIFF files
 - Fully color managed using [LittleCMS 2](https://littlecms.com/)
 - Not implemented in C
 - Provides a plain C API for easy integration into scripting languages
 - Ships with a `ctypes` Python binding and a C++ wrapper header
 - Minimal dependencies
+- Creates PDF 2.0 unless chosen PDF type (X, A, etc) requires a
+  specific older version
 
 ## Things the library does not do
 
@@ -26,7 +29,6 @@ directly.
 - Supporting any other backend than PDF
 - Parsing any vector data files like SVG
 - Data conversions in general (apart from colorspaces)
-- Supporting PDF versions earlier than 1.7 (possibly PDF 2.0)
 
 ## API stability guarantees
 

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -335,7 +335,7 @@ PdfVersion DocumentProperties::version() const {
             return PdfVersion::v13; // Not really correct, but goodenough.
         }
     }
-    return PdfVersion::v17;
+    return PdfVersion::v20;
 }
 
 bool DocumentProperties::use_rdf_metadata() const {


### PR DESCRIPTION
This should not break anything, but better to be sure I guess.

Ping @doctormo. This should not affect Inkscape, because if one specifies something like PDF/X3, the generated PDF version is 1.3. In theory people might complain that their default PDF exports have too new of a version, but AFAIK all major PDF renderers support 2.0.