### PR TITLE
[docs] How to install CapyPDF using Conan

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -3,7 +3,7 @@ Mostly notes to self, but these may be helpful to others.
 
 ## Dependencies
 - Install VS dev tools
-- From command prompt (not PS), activate VS dev tools, e.g. `"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"` (x64) 
+- From command prompt (not PS), activate VS dev tools, e.g. `"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"` (x64)
     - Note: by default, VsDevCmd targets x86 - this doesn't work as it raises errors related to `int32_t`/`uint32_t` conflict
 - Install meson (`pip install meson`)
 - Install Ninja (`winget install Ninja-build.Ninja`)
@@ -14,3 +14,22 @@ Mostly notes to self, but these may be helpful to others.
 ## Running CapyPDF programs on Windows
 - Windows needs the DLL to be in the path or the same directory as the exe, so either copy the DLL or edit with the absolute path to DLL, i.e:
   `set PATH=C:\path\to\src\;%PATH%`
+
+# Installing CapyPDF using Dependency Management Tools
+
+If you are using a dependency management tool,
+you can also install CapyPDF using the respective package manager,
+instead of compiling it from source code.
+
+## Conan
+
+You can download and install CapyPDF using the [Conan](https://conan.io/) dependency manager:
+
+```
+conan install -r conancenter --requires="capypdf/[*]" --build=missing
+```
+
+The CapyPDF package in Conan Center is maintained by
+[ConanCenterIndex](https://github.com/conan-io/conan-center-index) community.
+If the version is out of date or the package does not work,
+please create an issue or pull request on the [Conan Center Index repository](https://github.com/conan-io/conan-center-index).

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -15,21 +15,10 @@ Mostly notes to self, but these may be helpful to others.
 - Windows needs the DLL to be in the path or the same directory as the exe, so either copy the DLL or edit with the absolute path to DLL, i.e:
   `set PATH=C:\path\to\src\;%PATH%`
 
-# Installing CapyPDF using Dependency Management Tools
+## Installing via package managers
 
-If you are using a dependency management tool,
-you can also install CapyPDF using the respective package manager,
-instead of compiling it from source code.
+CapyPDF is available in the following package repositories:
 
-## Conan
-
-You can download and install CapyPDF using the [Conan](https://conan.io/) dependency manager:
-
-```
-conan install -r conancenter --requires="capypdf/[*]" --build=missing
-```
-
-The CapyPDF package in Conan Center is maintained by
-[ConanCenterIndex](https://github.com/conan-io/conan-center-index) community.
-If the version is out of date or the package does not work,
-please create an issue or pull request on the [Conan Center Index repository](https://github.com/conan-io/conan-center-index).
+- **Conan Center**: https://conan.io/center/recipes/capypdf
+  Install with: `conan install -r conancenter --requires="capypdf/[*]" --build=missing`
+  The package is maintained by the [ConanCenterIndex](https://github.com/conan-io/conan-center-index) community. For package issues, open a ticket there.


### PR DESCRIPTION
Greetings!

As CapyPDF is getting more popular around dependency managers, including Conan, I opened this PR to include a new entry in the documentation, pointing out how to install CapyPDF using a package manager.

Right now, version 0.21.0 is available in Conan Center: https://conan.io/center/recipes/capypdf?version=0.21.0

This can be the first entry of many, as I found AUR and Fedora having CapyPDF as well. 

Please let me know if it's okay to add the information in this file, or should this be moved to another place? Regards! 